### PR TITLE
[codex] Stabilize Philips AirPurifier polling recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ The integration uses a bounded polling model:
 
 - Every status refresh creates a fresh CoAP client.
 - The client performs the Philips sync/encryption handshake.
-- Home Assistant requests the current device status.
+- Home Assistant requests the current device status with a plain CoAP GET that does not set the Observe option.
 - The response updates the fan, sensor, switch, light, select, number, climate, and humidifier entities.
 - The CoAP client is shut down after the request completes.
 
-By keeping each CoAP exchange short-lived, a failed or timed-out request is isolated to that poll. The next poll starts with a new client instead of depending on a long-running observation stream.
+By keeping each CoAP exchange short-lived and avoiding CoAP Observe registrations, a failed or timed-out request is isolated to that poll. The next poll starts with a new client instead of depending on a long-running observation stream.
 
 ### Polling and Recovery
 
@@ -70,6 +70,7 @@ By keeping each CoAP exchange short-lived, a failed or timed-out request is isol
 - Minimum polling interval: **30 seconds**
 - Maximum polling interval: **300 seconds**
 - Successful polls use the device CoAP `max-age` value, clamped to the range above
+- Status polling intentionally avoids CoAP Observe so device-side observation streams do not accumulate
 - Connect, status, control, and shutdown calls have explicit timeouts
 - Status reads are retried before the coordinator marks the device unavailable
 - If Home Assistant restarts while the purifier is temporarily unreachable, cached status data is used to load the known entity set while background polling continues

--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@
 [issues_shield]: https://img.shields.io/github/issues/ruaan-deysel/ha-philips-airpurifier?style=flat-square&color=red
 [issues_link]: https://github.com/ruaan-deysel/ha-philips-airpurifier/issues
 
-A comprehensive **Local Push** integration for Philips air purifiers and humidifiers in Home Assistant. This integration provides complete control over your Philips air quality devices using the encrypted CoAP protocol for local communication.
+A comprehensive **Local Polling** integration for Philips air purifiers and humidifiers in Home Assistant. This integration provides complete control over your Philips air quality devices using the encrypted CoAP protocol for local communication.
 
 ## 📋 Table of Contents
 
 - [Features](#-features)
-- [Important Notice](#️-important-notice)
+- [How It Works](#how-it-works)
 - [Installation](#-installation)
   - [HACS Installation (Recommended)](#hacs-installation-recommended)
   - [Manual Installation](#manual-installation)
@@ -45,22 +45,36 @@ A comprehensive **Local Push** integration for Philips air purifiers and humidif
 - **Local Control**: Direct communication with your device without cloud dependency
 - **Auto-Discovery**: Automatic detection of compatible devices on your network
 - **Comprehensive Entity Support**: Fan, humidifier, sensors, switches, lights, and more
-- **Real-time Monitoring**: Air quality sensors, filter status, and device diagnostics
+- **Periodic Monitoring**: Air quality sensors, filter status, and device diagnostics
 - **Material Design Icons**: Entity icons are defined through `icons.json` following Home Assistant patterns
 - **Multi-language Support**: Available in English, German, Dutch, Bulgarian, Romanian, and Slovak
 - **HACS Compatible**: Easy installation and updates through HACS
 
-## ⚠️ Important Notice
+## ⚙️ How It Works
 
-**Please read this carefully before installation:**
+This integration communicates directly with Philips devices on your local network using encrypted CoAP over UDP port `5683`.
 
-Due to firmware limitations in Philips devices, this integration may experience stability issues. The connection might work initially but could become unresponsive over time. Common solutions include:
+The integration uses a bounded polling model:
 
-- Power cycling the Philips device
-- Restarting Home Assistant
-- Both actions combined
+- Every status refresh creates a fresh CoAP client.
+- The client performs the Philips sync/encryption handshake.
+- Home Assistant requests the current device status.
+- The response updates the fan, sensor, switch, light, select, number, climate, and humidifier entities.
+- The CoAP client is shut down after the request completes.
 
-This integration includes automatic reconnection attempts, but they may not always succeed. These issues are inherent to the device firmware and cannot be resolved at the integration level.
+By keeping each CoAP exchange short-lived, a failed or timed-out request is isolated to that poll. The next poll starts with a new client instead of depending on a long-running observation stream.
+
+### Polling and Recovery
+
+- Default polling interval: **60 seconds**
+- Minimum polling interval: **30 seconds**
+- Maximum polling interval: **300 seconds**
+- Successful polls use the device CoAP `max-age` value, clamped to the range above
+- Connect, status, control, and shutdown calls have explicit timeouts
+- Status reads are retried before the coordinator marks the device unavailable
+- If Home Assistant restarts while the purifier is temporarily unreachable, cached status data is used to load the known entity set while background polling continues
+
+Control actions also use short-lived CoAP clients. After a control command is sent, the integration updates the local state optimistically and schedules a follow-up status refresh.
 
 **Background**: This integration is based on reverse engineering work by [@rgerganov](https://github.com/rgerganov). Read more about the technical details [here](https://xakcop.com/post/ctrl-air-purifier/).
 
@@ -91,7 +105,7 @@ This integration includes automatic reconnection attempts, but they may not alwa
 
 - Home Assistant 2026.4.0 or newer
 - Philips air purifier/humidifier connected to your local network
-- Device must support local CoAP communication (see [Important Notice](#️-important-notice))
+- Device must support local CoAP communication (see [How It Works](#how-it-works))
 
 ### Setup Steps
 
@@ -129,7 +143,7 @@ If your device changes IP addresses:
 
 ## 📱 Supported Devices
 
-> **⚠️ Firmware Compatibility Warning**: Some newer firmware versions may disable local CoAP communication. If purchasing a device specifically for Home Assistant integration, ensure you can return it if the integration doesn't work.
+Devices must expose the local encrypted CoAP interface used by Philips air purifiers and humidifiers.
 
 ### Device Support Summary
 
@@ -264,8 +278,8 @@ Logs will be available in `home-assistant.log`.
 | Problem                 | Solution                                                   |
 | ----------------------- | ---------------------------------------------------------- |
 | Device not discovered   | Check network connectivity, ensure device supports CoAP    |
-| Connection drops        | Power cycle device, restart Home Assistant                 |
-| Entities unavailable    | Check device firmware version, verify local API is enabled |
+| Connection drops        | The next bounded poll starts with a fresh CoAP client      |
+| Entities unavailable    | Check device power, IP address, WiFi, and local CoAP access |
 | Integration not loading | Check Home Assistant logs, verify installation             |
 
 ### Getting Help for Unsupported Models

--- a/custom_components/philips_airpurifier/__init__.py
+++ b/custom_components/philips_airpurifier/__init__.py
@@ -9,11 +9,9 @@ from philips_airctrl import CoAPClient
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_NAME, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
-from .client import async_create_client
 from .const import (
     CONF_DEVICE_ID,
     CONF_MODEL,
@@ -64,14 +62,6 @@ async def async_setup_entry(
 
     _LOGGER.debug("async_setup_entry called for host %s", host)
 
-    try:
-        client = await async_create_client(host, timeout=25, create_client=CoAPClient.create)
-        _LOGGER.debug("Got a valid client for host %s", host)
-    except Exception as err:
-        _LOGGER.warning("Failed to connect to host %s: %s", host, err)
-        msg = f"Failed to connect to device at {host}"
-        raise ConfigEntryNotReady(msg) from err
-
     device_information = DeviceInformation(
         host=host,
         mac=None,
@@ -80,9 +70,15 @@ async def async_setup_entry(
         device_id=device_id,
     )
 
-    coordinator = PhilipsAirPurifierCoordinator(hass, client, host, device_information)
+    coordinator = PhilipsAirPurifierCoordinator(
+        hass,
+        host,
+        device_information,
+        initial_status=entry.data.get(CONF_STATUS),
+        create_client=CoAPClient.create,
+    )
 
-    # Perform initial data refresh, then start CoAP observation
+    # Perform initial data refresh, then let the coordinator poll at the device max-age.
     await coordinator.async_first_refresh_and_observe()
 
     hass.async_create_task(async_check_integration_health(hass, coordinator))

--- a/custom_components/philips_airpurifier/client.py
+++ b/custom_components/philips_airpurifier/client.py
@@ -4,14 +4,22 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import json
+import logging
 from typing import Any
 
+from aiocoap import Message, Unreliable
+from aiocoap.error import NetworkError
+from aiocoap.numbers.codes import GET
 from philips_airctrl import CoAPClient
 
 DEFAULT_CONNECT_TIMEOUT = 25
 DEFAULT_STATUS_TIMEOUT = 20
 DEFAULT_CONTROL_TIMEOUT = 20
 DEFAULT_SHUTDOWN_TIMEOUT = 5
+DEFAULT_STATUS_MAX_AGE = 60
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_create_client(
@@ -43,7 +51,10 @@ async def async_get_status(
     """Fetch current status using a temporary CoAP client and shut it down."""
     client = await async_create_client(host, timeout=connect_timeout, create_client=create_client)
     try:
-        return await asyncio.wait_for(client.get_status(), timeout=status_timeout)
+        return await asyncio.wait_for(
+            _async_get_status_without_observe(client),
+            timeout=status_timeout,
+        )
     finally:
         await async_shutdown_client(client, timeout=shutdown_timeout)
 
@@ -86,3 +97,35 @@ async def async_set_control_values(
             raise RuntimeError(msg)
     finally:
         await async_shutdown_client(client, timeout=shutdown_timeout)
+
+
+async def _async_get_status_without_observe(client: CoAPClient) -> tuple[dict[str, Any], int]:
+    """Fetch status with a plain CoAP GET, without registering Observe."""
+    client_context = getattr(client, "_client_context", None)
+    encryption_context = getattr(client, "_encryption_context", None)
+    if client_context is None or encryption_context is None:
+        msg = "CoAP client was not initialized"
+        raise RuntimeError(msg)
+
+    request = Message(
+        code=GET,
+        transport_tuning=Unreliable,
+        uri=f"coap://{client.host}:{client.port}{client.STATUS_PATH}",
+    )
+
+    try:
+        response = await client_context.request(request).response
+    except NetworkError:
+        _LOGGER.error("Network error while retrieving status from %s", client.host)
+        raise
+
+    payload_encrypted = response.payload.decode()
+    payload = encryption_context.decrypt(payload_encrypted)
+    state = json.loads(payload)
+
+    try:
+        max_age = response.opt.max_age
+    except AttributeError:
+        max_age = DEFAULT_STATUS_MAX_AGE
+
+    return state["state"]["reported"], max_age

--- a/custom_components/philips_airpurifier/client.py
+++ b/custom_components/philips_airpurifier/client.py
@@ -8,10 +8,15 @@ from typing import Any
 
 from philips_airctrl import CoAPClient
 
+DEFAULT_CONNECT_TIMEOUT = 25
+DEFAULT_STATUS_TIMEOUT = 20
+DEFAULT_CONTROL_TIMEOUT = 20
+DEFAULT_SHUTDOWN_TIMEOUT = 5
+
 
 async def async_create_client(
     host: str,
-    timeout: float = 25,
+    timeout: float = DEFAULT_CONNECT_TIMEOUT,
     create_client: Any | None = None,
 ) -> CoAPClient:
     """Create a CoAP client for a host with timeout protection."""
@@ -19,17 +24,65 @@ async def async_create_client(
     return await asyncio.wait_for(creator(host), timeout=timeout)
 
 
-async def async_fetch_status(
+async def async_shutdown_client(
+    client: CoAPClient,
+    timeout: float = DEFAULT_SHUTDOWN_TIMEOUT,
+) -> None:
+    """Shut down a CoAP client without allowing cleanup to hang Home Assistant."""
+    with contextlib.suppress(Exception):
+        await asyncio.wait_for(client.shutdown(), timeout=timeout)
+
+
+async def async_get_status(
     host: str,
-    connect_timeout: float = 30,
-    status_timeout: float = 30,
+    connect_timeout: float = DEFAULT_CONNECT_TIMEOUT,
+    status_timeout: float = DEFAULT_STATUS_TIMEOUT,
+    shutdown_timeout: float = DEFAULT_SHUTDOWN_TIMEOUT,
     create_client: Any | None = None,
-) -> dict[str, Any]:
+) -> tuple[dict[str, Any], int]:
     """Fetch current status using a temporary CoAP client and shut it down."""
     client = await async_create_client(host, timeout=connect_timeout, create_client=create_client)
     try:
-        status, _ = await asyncio.wait_for(client.get_status(), timeout=status_timeout)
-        return status
+        return await asyncio.wait_for(client.get_status(), timeout=status_timeout)
     finally:
-        with contextlib.suppress(Exception):
-            await client.shutdown()
+        await async_shutdown_client(client, timeout=shutdown_timeout)
+
+
+async def async_fetch_status(
+    host: str,
+    connect_timeout: float = DEFAULT_CONNECT_TIMEOUT,
+    status_timeout: float = DEFAULT_STATUS_TIMEOUT,
+    shutdown_timeout: float = DEFAULT_SHUTDOWN_TIMEOUT,
+    create_client: Any | None = None,
+) -> dict[str, Any]:
+    """Fetch current status using a temporary CoAP client and shut it down."""
+    status, _ = await async_get_status(
+        host,
+        connect_timeout=connect_timeout,
+        status_timeout=status_timeout,
+        shutdown_timeout=shutdown_timeout,
+        create_client=create_client,
+    )
+    return status
+
+
+async def async_set_control_values(
+    host: str,
+    data: dict[str, Any],
+    connect_timeout: float = DEFAULT_CONNECT_TIMEOUT,
+    control_timeout: float = DEFAULT_CONTROL_TIMEOUT,
+    shutdown_timeout: float = DEFAULT_SHUTDOWN_TIMEOUT,
+    create_client: Any | None = None,
+) -> None:
+    """Set control values using a temporary CoAP client and bounded waits."""
+    client = await async_create_client(host, timeout=connect_timeout, create_client=create_client)
+    try:
+        result = await asyncio.wait_for(
+            client.set_control_values(data=data),
+            timeout=control_timeout,
+        )
+        if result is False:
+            msg = f"Device at {host} rejected control update"
+            raise RuntimeError(msg)
+    finally:
+        await async_shutdown_client(client, timeout=shutdown_timeout)

--- a/custom_components/philips_airpurifier/coordinator.py
+++ b/custom_components/philips_airpurifier/coordinator.py
@@ -3,16 +3,17 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
+from collections.abc import Awaitable, Callable
+from datetime import timedelta
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from philips_airctrl import CoAPClient
 
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .client import async_create_client
+from .client import async_get_status, async_set_control_values
 from .const import DOMAIN
 from .device_models import DEVICE_MODELS
 from .model import ApiGeneration, DeviceInformation, DeviceModelConfig
@@ -22,37 +23,51 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-MISSED_PACKAGE_COUNT = 3
-DEFAULT_TIMEOUT = 60
+DEFAULT_POLL_INTERVAL = 60
+MIN_POLL_INTERVAL = 30
+MAX_POLL_INTERVAL = 300
+STATUS_RETRY_COUNT = 3
+STATUS_RETRY_DELAY = 2
 
 
 class PhilipsAirPurifierCoordinator(DataUpdateCoordinator[dict[str, Any]]):
-    """Coordinator to manage data from Philips AirPurifier via CoAP push."""
+    """Coordinator to manage data from Philips AirPurifier via bounded CoAP polling."""
 
     def __init__(
         self,
         hass: HomeAssistant,
-        client: CoAPClient,
-        host: str,
-        device_info: DeviceInformation,
+        host: str | CoAPClient,
+        device_info: DeviceInformation | str,
+        legacy_device_info: DeviceInformation | None = None,
+        initial_status: dict[str, Any] | None = None,
+        create_client: Any | None = None,
     ) -> None:
         """Initialize the coordinator."""
+        legacy_client: CoAPClient | None = None
+        if not isinstance(host, str):
+            legacy_client = host
+            host = cast("str", device_info)
+            device_info = cast("DeviceInformation", legacy_device_info)
+        else:
+            device_info = cast("DeviceInformation", device_info)
+
         super().__init__(
             hass,
             _LOGGER,
             name=DOMAIN,
+            update_interval=timedelta(seconds=DEFAULT_POLL_INTERVAL),
         )
-        self.client = client
+        self.client = legacy_client
+        self._create_client = create_client or _client_factory_from_legacy_client(legacy_client) or CoAPClient.create
         self.host = host
         self.device_info = device_info
 
-        self._observe_task: asyncio.Task[None] | None = None
-        self._reconnect_task: asyncio.Task[None] | None = None
-        self._timeout: int = DEFAULT_TIMEOUT
-        self._watchdog_task: asyncio.Task[None] | None = None
+        self._timeout: int = DEFAULT_POLL_INTERVAL
         self._last_update: float = 0.0
         self._device_available = True
         self._shutting_down: bool = False
+        self._initial_status = initial_status
+        self._control_lock = asyncio.Lock()
 
     def _mark_unavailable(self, reason: str) -> None:
         """Mark the device unavailable and log transition once."""
@@ -102,146 +117,101 @@ class PhilipsAirPurifierCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def async_set_control_values(self, values: dict[str, Any]) -> None:
         """Set multiple control values on the device."""
-        await self.client.set_control_values(data=values)
+        async with self._control_lock:
+            try:
+                await async_set_control_values(
+                    self.host,
+                    data=values,
+                    create_client=self._create_client,
+                )
+            except Exception:
+                self._mark_unavailable("control update failed")
+                raise
+
+            if self.data is not None:
+                self.async_set_updated_data({**self.data, **values})
+
+            self.hass.async_create_background_task(
+                self.async_request_refresh(),
+                f"philips_airpurifier_refresh_after_control_{self.host}",
+            )
 
     async def _async_update_data(self) -> dict[str, Any]:
-        """Fetch data from the device (used for initial refresh and fallback)."""
-        try:
-            status, timeout = await self.client.get_status()
-            self._timeout = timeout
-            self._mark_available()
-            return status
-        except Exception as err:
-            self._mark_unavailable("status update failed")
-            msg = f"Error communicating with device at {self.host}"
-            raise UpdateFailed(msg) from err
+        """Fetch data from the device."""
+        last_error: Exception | None = None
+        for attempt in range(1, STATUS_RETRY_COUNT + 1):
+            try:
+                status, timeout = await async_get_status(
+                    self.host,
+                    create_client=self._create_client,
+                )
+                self._timeout = timeout
+                self.update_interval = _poll_interval_from_timeout(timeout)
+                self._last_update = asyncio.get_running_loop().time()
+                self._mark_available()
+                return status
+            except Exception as err:
+                last_error = err
+                if attempt < STATUS_RETRY_COUNT:
+                    _LOGGER.debug(
+                        "Status poll %d/%d failed for %s; retrying",
+                        attempt,
+                        STATUS_RETRY_COUNT,
+                        self.host,
+                        exc_info=True,
+                    )
+                    await asyncio.sleep(STATUS_RETRY_DELAY * attempt)
+
+        self._mark_unavailable("status update failed")
+        msg = f"Error communicating with device at {self.host}"
+        raise UpdateFailed(msg) from last_error
 
     def _start_observing(self) -> None:
-        """Start observing device status via CoAP push."""
-        if self._observe_task is not None:
-            self._observe_task.cancel()
-
-        self._observe_task = self.hass.async_create_background_task(
-            self._async_observe_status(),
-            f"philips_airpurifier_observe_{self.host}",
-        )
-
-        if self._watchdog_task is not None:
-            self._watchdog_task.cancel()
-
-        self._watchdog_task = self.hass.async_create_background_task(
-            self._async_watchdog(),
-            f"philips_airpurifier_watchdog_{self.host}",
-        )
-
-    async def _async_observe_status(self) -> None:
-        """Observe device status via CoAP push updates."""
-        try:
-            async for status in self.client.observe_status():
-                self._last_update = asyncio.get_event_loop().time()
-                self._mark_available()
-                self.async_set_updated_data(status)
-        except asyncio.CancelledError:
-            raise
-        except Exception:
-            _LOGGER.debug(
-                "Observation stream ended for %s, triggering reconnect",
-                self.host,
-            )
-        finally:
-            if not self._shutting_down:
-                self._mark_unavailable("observation stream ended")
-                self.hass.async_create_background_task(
-                    self._async_reconnect(),
-                    f"philips_airpurifier_reconnect_{self.host}",
-                )
-
-    async def _async_watchdog(self) -> None:
-        """Watch for missed updates and trigger reconnect if needed."""
-        while True:
-            await asyncio.sleep(self._timeout * MISSED_PACKAGE_COUNT)
-            if self._last_update > 0:
-                elapsed = asyncio.get_event_loop().time() - self._last_update
-                if elapsed > self._timeout * MISSED_PACKAGE_COUNT:
-                    self._mark_unavailable("watchdog timeout")
-                    _LOGGER.warning(
-                        "No updates from %s for %d seconds, reconnecting",
-                        self.host,
-                        int(elapsed),
-                    )
-                    await self._async_reconnect()
-
-    async def _async_reconnect(self) -> None:
-        """Reconnect to the device."""
-        if self._reconnect_task is not None and not self._reconnect_task.done():
-            return
-
-        self._reconnect_task = self.hass.async_create_background_task(
-            self._do_reconnect(),
-            f"philips_airpurifier_reconnect_{self.host}",
-        )
-
-    async def _do_reconnect(self) -> None:
-        """Perform the actual reconnect."""
-        try:
-            with contextlib.suppress(Exception):
-                await self.client.shutdown()
-
-            self.client = await async_create_client(self.host, create_client=CoAPClient.create)
-            _LOGGER.info("Reconnected to %s", self.host)
-
-            try:
-                status, timeout = await self.client.get_status()
-                self._timeout = timeout
-                self._mark_available()
-                self.async_set_updated_data(status)
-            except Exception:
-                self._mark_unavailable("reconnect status fetch failed")
-                _LOGGER.debug(
-                    "Failed to get status after reconnect to %s",
-                    self.host,
-                )
-
-            self._start_observing()
-        except asyncio.CancelledError:
-            raise
-        except Exception:
-            _LOGGER.exception("Reconnect to %s failed", self.host)
+        """Compatibility shim for older tests; status is now refreshed by polling."""
+        _LOGGER.debug("CoAP observe mode is disabled for %s; using bounded polling", self.host)
 
     async def async_first_refresh_and_observe(self) -> None:
-        """Perform first refresh and start observing."""
+        """Perform first refresh and schedule periodic polling."""
+        if self._initial_status:
+            self.async_set_updated_data(self._initial_status)
+            self._mark_unavailable("awaiting live status")
+            self.hass.async_create_background_task(
+                self.async_request_refresh(),
+                f"philips_airpurifier_initial_refresh_{self.host}",
+            )
+            return
+
         try:
-            status, timeout = await self.client.get_status()
-            self._timeout = timeout
-            self._mark_available()
-            self.async_set_updated_data(status)
+            await self.async_config_entry_first_refresh()
             _LOGGER.debug("First refresh completed for %s", self.host)
         except Exception as err:
-            self._mark_unavailable("initial refresh failed")
             msg = f"Failed to connect to device at {self.host}"
             raise ConfigEntryNotReady(msg) from err
-
-        self._last_update = asyncio.get_event_loop().time()
-        self._start_observing()
 
     async def async_shutdown(self) -> None:
         """Shut down the coordinator."""
         self._shutting_down = True
 
-        tasks_to_cancel: list[asyncio.Task[None]] = []
-        for task in (self._observe_task, self._watchdog_task, self._reconnect_task):
-            if task is not None and not task.done():
-                task.cancel()
-                tasks_to_cancel.append(task)
 
-        self._observe_task = None
-        self._watchdog_task = None
-        self._reconnect_task = None
+def _poll_interval_from_timeout(timeout: int) -> timedelta:
+    """Return a bounded polling interval from the device CoAP max-age value."""
+    try:
+        seconds = int(timeout)
+    except (TypeError, ValueError):
+        seconds = DEFAULT_POLL_INTERVAL
 
-        for task in tasks_to_cancel:
-            with contextlib.suppress(asyncio.CancelledError):
-                await task
+    seconds = min(max(seconds, MIN_POLL_INTERVAL), MAX_POLL_INTERVAL)
+    return timedelta(seconds=seconds)
 
-        if self.client is not None:
-            with contextlib.suppress(Exception):
-                await self.client.shutdown()
+
+def _client_factory_from_legacy_client(
+    client: CoAPClient | None,
+) -> Callable[[str], Awaitable[CoAPClient]] | None:
+    """Return a create_client callback for older tests that pass a client."""
+    if client is None:
+        return None
+
+    async def _create_client(_host: str) -> CoAPClient:
+        return client
+
+    return _create_client

--- a/custom_components/philips_airpurifier/diagnostics.py
+++ b/custom_components/philips_airpurifier/diagnostics.py
@@ -84,7 +84,10 @@ async def async_get_config_entry_diagnostics(
             "state": entry.state.value,
         },
         "coordinator": {
-            "client_available": coordinator.client is not None,
+            "client_available": coordinator.last_update_success,
+            "poll_interval_seconds": (
+                int(coordinator.update_interval.total_seconds()) if coordinator.update_interval else None
+            ),
             "has_data": status is not None and len(status) > 0,
             "status_keys": list(status.keys()) if status else [],
         },

--- a/custom_components/philips_airpurifier/manifest.json
+++ b/custom_components/philips_airpurifier/manifest.json
@@ -26,8 +26,8 @@
   ],
   "documentation": "https://github.com/ruaan-deysel/ha-philips-airpurifier",
   "integration_type": "device",
-  "iot_class": "local_push",
+  "iot_class": "local_polling",
   "issue_tracker": "https://github.com/ruaan-deysel/ha-philips-airpurifier/issues",
   "requirements": ["philips-airctrl==1.0.0"],
-  "version": "2026.4.1"
+  "version": "2026.4.2"
 }

--- a/custom_components/philips_airpurifier/manifest.json
+++ b/custom_components/philips_airpurifier/manifest.json
@@ -29,5 +29,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/ruaan-deysel/ha-philips-airpurifier/issues",
   "requirements": ["philips-airctrl==1.0.0"],
-  "version": "2026.4.2"
+  "version": "2026.4.3"
 }

--- a/custom_components/philips_airpurifier/repairs.py
+++ b/custom_components/philips_airpurifier/repairs.py
@@ -363,7 +363,14 @@ async def async_check_integration_health(
 ) -> None:  # pragma: no cover
     """Check integration health and create repair issues if needed."""
     # Check connectivity
-    if not coordinator.client:
+    last_update_success = getattr(coordinator, "last_update_success", None)
+    connected = (
+        last_update_success
+        if isinstance(last_update_success, bool)
+        else getattr(coordinator, "client", None) is not None
+    )
+
+    if not connected:
         async_create_issue(
             hass,
             "connectivity_issue",

--- a/custom_components/philips_airpurifier/sensor.py
+++ b/custom_components/philips_airpurifier/sensor.py
@@ -99,7 +99,7 @@ class PhilipsSensor(PhilipsAirPurifierEntity, SensorEntity):
             return icon
         try:
             value = int(native_value)
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             return icon
 
         for level_value, level_icon in self._icon_map.items():
@@ -218,7 +218,7 @@ class PhilipsFilterSensor(PhilipsAirPurifierEntity, SensorEntity):
             return icon
         try:
             value = int(native_value)
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             return icon
 
         for level_value, level_icon in self._icon_map.items():

--- a/scripts/monitor_homeassistant_philips.ps1
+++ b/scripts/monitor_homeassistant_philips.ps1
@@ -1,0 +1,175 @@
+param(
+    [string]$HomeAssistantUrl = "http://192.168.1.153:8123",
+    [string]$Username = $env:HA_USERNAME,
+    [securestring]$Password,
+    [string]$PasswordPlain = $env:HA_PASSWORD,
+    [int]$DurationMinutes = 30,
+    [int]$IntervalSeconds = 60,
+    [string]$EntityPattern = "air_purifier",
+    [string]$SambaShare = "\\192.168.1.153\config",
+    [switch]$SkipLogs
+)
+
+$ErrorActionPreference = "Stop"
+
+function ConvertTo-PlainText {
+    param([securestring]$Secure)
+    if ($null -eq $Secure) {
+        return $null
+    }
+    $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($Secure)
+    try {
+        return [Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
+    }
+    finally {
+        [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+    }
+}
+
+function Get-HomeAssistantToken {
+    param(
+        [string]$BaseUrl,
+        [string]$User,
+        [string]$PlainPassword
+    )
+
+    $clientId = "http://localhost/"
+    $flowBody = @{
+        client_id = $clientId
+        handler = @("homeassistant", $null)
+        redirect_uri = "http://localhost/"
+    } | ConvertTo-Json
+
+    $flow = Invoke-RestMethod -Method Post -Uri "$BaseUrl/auth/login_flow" -ContentType "application/json" -Body $flowBody
+
+    $loginBody = @{
+        username = $User
+        password = $PlainPassword
+        client_id = $clientId
+    } | ConvertTo-Json
+
+    $login = Invoke-RestMethod `
+        -Method Post `
+        -Uri "$BaseUrl/auth/login_flow/$($flow.flow_id)" `
+        -ContentType "application/json" `
+        -Body $loginBody
+
+    Invoke-RestMethod `
+        -Method Post `
+        -Uri "$BaseUrl/auth/token" `
+        -ContentType "application/x-www-form-urlencoded" `
+        -Body @{
+            grant_type = "authorization_code"
+            code = $login.result
+            client_id = $clientId
+        }
+}
+
+function Get-PhilipsLogLines {
+    param(
+        [string]$Share,
+        [string]$User,
+        [securestring]$SecurePassword
+    )
+
+    if ($SkipLogs -or -not $Share) {
+        return @()
+    }
+
+    $driveName = "HAMonitor"
+    if (Get-PSDrive -Name $driveName -ErrorAction SilentlyContinue) {
+        Remove-PSDrive -Name $driveName -Force
+    }
+
+    $cred = New-Object System.Management.Automation.PSCredential($User, $SecurePassword)
+    New-PSDrive -Name $driveName -PSProvider FileSystem -Root $Share -Credential $cred -Scope Script | Out-Null
+
+    try {
+        $paths = @(
+            "$($driveName):\home-assistant.log",
+            "$($driveName):\home-assistant.log.fault"
+        )
+        foreach ($path in $paths) {
+            if (Test-Path $path) {
+                return Get-Content -Tail 500 $path |
+                    Select-String -Pattern "philips|airpurifier|aiocoap|coap|unavailable|reconnect|failed|exception|traceback" -CaseSensitive:$false |
+                    ForEach-Object { $_.Line }
+            }
+        }
+    }
+    finally {
+        Remove-PSDrive -Name $driveName -Force -ErrorAction SilentlyContinue
+    }
+
+    @()
+}
+
+if (-not $Username) {
+    throw "Provide -Username or set HA_USERNAME."
+}
+
+if (-not $PasswordPlain) {
+    if ($null -eq $Password) {
+        $Password = Read-Host "Home Assistant password" -AsSecureString
+    }
+    $PasswordPlain = ConvertTo-PlainText $Password
+}
+elseif ($null -eq $Password) {
+    $Password = ConvertTo-SecureString $PasswordPlain -AsPlainText -Force
+}
+
+$token = Get-HomeAssistantToken -BaseUrl $HomeAssistantUrl.TrimEnd("/") -User $Username -PlainPassword $PasswordPlain
+$headers = @{ Authorization = "Bearer $($token.access_token)" }
+$endAt = (Get-Date).AddMinutes($DurationMinutes)
+$samples = @()
+$unavailableSamples = 0
+
+while ((Get-Date) -lt $endAt) {
+    $states = Invoke-RestMethod -Method Get -Uri "$($HomeAssistantUrl.TrimEnd('/'))/api/states" -Headers $headers
+    $entities = @(
+        $states | Where-Object {
+            $_.entity_id -match $EntityPattern -and $_.entity_id -notmatch "^update\."
+        }
+    )
+    $unavailable = @($entities | Where-Object { $_.state -eq "unavailable" })
+    $unknown = @($entities | Where-Object { $_.state -eq "unknown" })
+    $pm25 = $states | Where-Object { $_.entity_id -eq "sensor.air_purifier_pm2_5" } | Select-Object -First 1
+    $rssi = $states | Where-Object { $_.entity_id -eq "sensor.air_purifier_rssi" } | Select-Object -First 1
+
+    if ($unavailable.Count -gt 0) {
+        $unavailableSamples++
+    }
+
+    $sample = [pscustomobject]@{
+        timestamp = (Get-Date).ToString("s")
+        entity_count = $entities.Count
+        unavailable = $unavailable.Count
+        unknown = $unknown.Count
+        fan = ($states | Where-Object { $_.entity_id -eq "fan.air_purifier" } | Select-Object -First 1).state
+        pm25 = $pm25.state
+        rssi = $rssi.state
+    }
+    $samples += $sample
+    $sample | ConvertTo-Json -Compress
+
+    Start-Sleep -Seconds $IntervalSeconds
+}
+
+$logLines = Get-PhilipsLogLines -Share $SambaShare -User $Username -SecurePassword $Password
+$errorLogLines = @(
+    $logLines | Select-String -Pattern "failed|exception|traceback|unavailable|error" -CaseSensitive:$false |
+        ForEach-Object { $_.Line }
+)
+
+[pscustomobject]@{
+    result = if ($unavailableSamples -eq 0 -and $errorLogLines.Count -eq 0) { "pass" } else { "review" }
+    samples = $samples.Count
+    unavailable_samples = $unavailableSamples
+    matching_log_lines = $logLines.Count
+    error_log_lines = $errorLogLines.Count
+    final_sample = $samples[-1]
+} | ConvertTo-Json -Depth 5
+
+if ($unavailableSamples -gt 0 -or $errorLogLines.Count -gt 0) {
+    exit 1
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
 
@@ -21,7 +23,58 @@ from homeassistant.core import HomeAssistant
 from .const import MOCK_STATUS_GEN1, TEST_DEVICE_ID, TEST_HOST, TEST_MODEL, TEST_NAME
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from collections.abc import Generator
+
+
+class _MockStatusRequester:
+    """Small aiocoap requester stand-in with an awaitable response."""
+
+    def __init__(self, client: AsyncMock) -> None:
+        async def _response() -> SimpleNamespace:
+            if client.status_error is not None:
+                raise client.status_error
+            payload = json.dumps({"state": {"reported": client.status_data}}).encode()
+            return SimpleNamespace(
+                payload=payload,
+                opt=SimpleNamespace(max_age=client.status_max_age),
+            )
+
+        self.response = _response()
+
+
+class _MockClientContext:
+    """Record CoAP requests issued by the integration."""
+
+    def __init__(self, client: AsyncMock) -> None:
+        self._client = client
+
+    def request(self, request: Any) -> _MockStatusRequester:
+        """Return a mocked requester for a status poll."""
+        self._client.status_requests.append(request)
+        return _MockStatusRequester(self._client)
+
+
+class _MockEncryptionContext:
+    """Return plaintext test payloads unchanged."""
+
+    def decrypt(self, payload: str) -> str:
+        """Decrypt a payload."""
+        return payload
+
+
+def _configure_status_poll_client(client: AsyncMock, status: dict[str, Any]) -> None:
+    """Configure a mock CoAP client for non-observe status polling."""
+    client.host = TEST_HOST
+    client.port = 5683
+    client.STATUS_PATH = "/sys/dev/status"
+    client.status_data = status.copy()
+    client.status_max_age = 60
+    client.status_error = None
+    client.status_requests = []
+    client._client_context = _MockClientContext(client)
+    client._encryption_context = _MockEncryptionContext()
 
 
 @pytest.fixture
@@ -57,6 +110,7 @@ def mock_coap_client() -> Generator[AsyncMock]:
         client.set_control_values = AsyncMock()
         client.set_control_value = AsyncMock()
         client.shutdown = AsyncMock()
+        _configure_status_poll_client(client, MOCK_STATUS_GEN1)
 
         mock_client_cls.create = AsyncMock(return_value=client)
         mock_client_cls.return_value = client

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import json
 from datetime import timedelta
+from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -21,6 +24,40 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from .const import MOCK_STATUS_GEN1, TEST_DEVICE_ID, TEST_HOST, TEST_MODEL, TEST_NAME
+
+
+class _TestStatusRequester:
+    """Small aiocoap requester stand-in with an awaitable response."""
+
+    def __init__(self, client: AsyncMock) -> None:
+        async def _response() -> SimpleNamespace:
+            payload = json.dumps({"state": {"reported": client.status_data}}).encode()
+            return SimpleNamespace(
+                payload=payload,
+                opt=SimpleNamespace(max_age=client.status_max_age),
+            )
+
+        self.response = _response()
+
+
+class _TestClientContext:
+    """Record status poll requests."""
+
+    def __init__(self, client: AsyncMock) -> None:
+        self._client = client
+
+    def request(self, request: Any) -> _TestStatusRequester:
+        """Return a mocked requester."""
+        self._client.status_requests.append(request)
+        return _TestStatusRequester(self._client)
+
+
+class _TestEncryptionContext:
+    """Return plaintext test payloads unchanged."""
+
+    def decrypt(self, payload: str) -> str:
+        """Decrypt a payload."""
+        return payload
 
 
 async def test_coordinator_data_available(
@@ -119,20 +156,22 @@ async def test_coordinator_async_update_data(
     init_integration: MockConfigEntry,
     mock_coap_client: AsyncMock,
 ) -> None:
-    """Test coordinator polling calls get_status and updates interval."""
+    """Test coordinator polling uses non-observe status GET and updates interval."""
     coordinator = init_integration.runtime_data
 
-    mock_coap_client.get_status.reset_mock()
+    mock_coap_client.status_requests.clear()
     updated_status = MOCK_STATUS_GEN1.copy()
     updated_status["pm25"] = 25
-    mock_coap_client.get_status.return_value = (updated_status, 45)
+    mock_coap_client.status_data = updated_status
+    mock_coap_client.status_max_age = 45
 
     result = await coordinator._async_update_data()
 
     assert result == updated_status
     assert result["pm25"] == 25
     assert coordinator.update_interval == timedelta(seconds=45)
-    mock_coap_client.get_status.assert_called_once()
+    assert len(mock_coap_client.status_requests) == 1
+    assert mock_coap_client.status_requests[0].opt.observe is None
     mock_coap_client.shutdown.assert_called()
 
 
@@ -144,7 +183,7 @@ async def test_coordinator_async_update_data_error(
     """Test coordinator update data raises UpdateFailed on error."""
     coordinator = init_integration.runtime_data
 
-    mock_coap_client.get_status.side_effect = RuntimeError("connection error")
+    mock_coap_client.status_error = RuntimeError("connection error")
 
     with pytest.raises(UpdateFailed):
         await coordinator._async_update_data()
@@ -278,7 +317,15 @@ async def test_first_refresh_uses_cached_status_when_device_offline(hass: HomeAs
 async def test_first_refresh_and_observe_success(hass: HomeAssistant) -> None:
     """Test initial refresh stores data in polling mode."""
     client = AsyncMock()
-    client.get_status = AsyncMock(return_value=({"pwr": "1"}, 30))
+    client.host = TEST_HOST
+    client.port = 5683
+    client.STATUS_PATH = "/sys/dev/status"
+    client.status_data = {"pwr": "1"}
+    client.status_max_age = 30
+    client.status_error = None
+    client.status_requests = []
+    client._client_context = _TestClientContext(client)
+    client._encryption_context = _TestEncryptionContext()
     client.shutdown = AsyncMock()
     coordinator = _make_coordinator(hass, client=client)
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
-import asyncio
+from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.philips_airpurifier.coordinator import (
+    DEFAULT_POLL_INTERVAL,
+    MAX_POLL_INTERVAL,
+    MIN_POLL_INTERVAL,
     PhilipsAirPurifierCoordinator,
+    _poll_interval_from_timeout,
 )
 from custom_components.philips_airpurifier.model import DeviceInformation
 from homeassistant.core import HomeAssistant
@@ -43,6 +47,7 @@ async def test_coordinator_properties(
     assert coordinator.device_name == TEST_NAME
     assert coordinator.model == TEST_MODEL
     assert coordinator.host == TEST_HOST
+    assert coordinator.update_interval == timedelta(seconds=60)
 
 
 async def test_coordinator_device_info(
@@ -54,7 +59,6 @@ async def test_coordinator_device_info(
 
     device_info = coordinator.device_info
 
-    # device_info is a DeviceInformation dataclass, not a HA DeviceInfo dict
     assert isinstance(device_info, DeviceInformation)
     assert device_info.model == TEST_MODEL
     assert device_info.name == TEST_NAME
@@ -67,12 +71,15 @@ async def test_coordinator_set_control_value(
     init_integration: MockConfigEntry,
     mock_coap_client: AsyncMock,
 ) -> None:
-    """Test setting a single control value."""
+    """Test setting a single control value uses a bounded temporary client."""
     coordinator = init_integration.runtime_data
+    mock_coap_client.set_control_values.reset_mock()
 
     await coordinator.async_set_control_value("pwr", "0")
 
-    mock_coap_client.set_control_values.assert_called_once_with(data={"pwr": "0"})
+    mock_coap_client.set_control_values.assert_called_with(data={"pwr": "0"})
+    mock_coap_client.shutdown.assert_called()
+    assert coordinator.data["pwr"] == "0"
 
 
 async def test_coordinator_set_control_values(
@@ -82,11 +89,13 @@ async def test_coordinator_set_control_values(
 ) -> None:
     """Test setting multiple control values."""
     coordinator = init_integration.runtime_data
+    mock_coap_client.set_control_values.reset_mock()
 
     values = {"pwr": "1", "mode": "M", "om": "s"}
     await coordinator.async_set_control_values(values)
 
-    mock_coap_client.set_control_values.assert_called_once_with(data=values)
+    mock_coap_client.set_control_values.assert_called_with(data=values)
+    assert coordinator.data["mode"] == "M"
 
 
 async def test_coordinator_set_control_values_error(
@@ -94,14 +103,15 @@ async def test_coordinator_set_control_values_error(
     init_integration: MockConfigEntry,
     mock_coap_client: AsyncMock,
 ) -> None:
-    """Test setting control values propagates errors."""
+    """Test setting control values propagates errors and marks unavailable."""
     coordinator = init_integration.runtime_data
 
-    mock_coap_client.set_control_values.side_effect = Exception("connection lost")
+    mock_coap_client.set_control_values.side_effect = RuntimeError("connection lost")
 
-    # The method doesn't wrap errors in UpdateFailed, it just propagates the exception
-    with pytest.raises(Exception, match="connection lost"):
+    with pytest.raises(RuntimeError, match="connection lost"):
         await coordinator.async_set_control_values({"pwr": "1"})
+
+    assert coordinator.last_update_success is False
 
 
 async def test_coordinator_async_update_data(
@@ -109,23 +119,21 @@ async def test_coordinator_async_update_data(
     init_integration: MockConfigEntry,
     mock_coap_client: AsyncMock,
 ) -> None:
-    """Test coordinator update data calls get_status."""
+    """Test coordinator polling calls get_status and updates interval."""
     coordinator = init_integration.runtime_data
 
-    # Reset the mock to clear initialization calls
     mock_coap_client.get_status.reset_mock()
-
-    # Mock updated status
     updated_status = MOCK_STATUS_GEN1.copy()
     updated_status["pm25"] = 25
-    mock_coap_client.get_status.return_value = (updated_status, 60)
+    mock_coap_client.get_status.return_value = (updated_status, 45)
 
-    # Call internal update method
     result = await coordinator._async_update_data()
 
     assert result == updated_status
     assert result["pm25"] == 25
+    assert coordinator.update_interval == timedelta(seconds=45)
     mock_coap_client.get_status.assert_called_once()
+    mock_coap_client.shutdown.assert_called()
 
 
 async def test_coordinator_async_update_data_error(
@@ -136,29 +144,24 @@ async def test_coordinator_async_update_data_error(
     """Test coordinator update data raises UpdateFailed on error."""
     coordinator = init_integration.runtime_data
 
-    mock_coap_client.get_status.side_effect = Exception("connection error")
+    mock_coap_client.get_status.side_effect = RuntimeError("connection error")
 
     with pytest.raises(UpdateFailed):
         await coordinator._async_update_data()
+
+    assert coordinator.last_update_success is False
 
 
 async def test_coordinator_shutdown(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
-    mock_coap_client: AsyncMock,
 ) -> None:
-    """Test coordinator shutdown cancels tasks and shuts down client."""
+    """Test coordinator shutdown marks the coordinator as shutting down."""
     coordinator = init_integration.runtime_data
 
     await coordinator.async_shutdown()
 
-    # Verify client shutdown was called
-    mock_coap_client.shutdown.assert_called()
-
-    # Verify tasks are None after shutdown
-    assert coordinator._observe_task is None
-    assert coordinator._watchdog_task is None
-    assert coordinator._reconnect_task is None
+    assert coordinator._shutting_down is True
 
 
 async def test_coordinator_model_config(
@@ -171,19 +174,18 @@ async def test_coordinator_model_config(
     model_config = coordinator.model_config
 
     assert model_config is not None
-    # DeviceModelConfig has api_generation, not model
     assert model_config.api_generation == "gen1"
 
 
-async def test_coordinator_client_property(
+async def test_coordinator_legacy_client_property(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
     mock_coap_client: AsyncMock,
 ) -> None:
-    """Test coordinator client property returns the CoAP client."""
+    """Test coordinator keeps the legacy client attribute for diagnostics compatibility."""
     coordinator = init_integration.runtime_data
 
-    assert coordinator.client == mock_coap_client
+    assert coordinator.client is None or coordinator.client == mock_coap_client
 
 
 async def test_coordinator_mark_available_logs_back_online_once(hass: HomeAssistant) -> None:
@@ -211,7 +213,9 @@ def _make_coordinator(
         device_id=TEST_DEVICE_ID,
         host=TEST_HOST,
     )
-    return PhilipsAirPurifierCoordinator(hass, client or AsyncMock(), TEST_HOST, device_info)
+    if client is not None:
+        return PhilipsAirPurifierCoordinator(hass, client, TEST_HOST, device_info)
+    return PhilipsAirPurifierCoordinator(hass, TEST_HOST, device_info, create_client=AsyncMock())
 
 
 async def test_coordinator_model_config_family_fallback(hass: HomeAssistant) -> None:
@@ -228,340 +232,90 @@ async def test_coordinator_model_config_default_fallback(hass: HomeAssistant) ->
     assert coordinator.model_config.api_generation == "gen1"
 
 
-async def test_start_observing_cancels_existing_tasks(hass: HomeAssistant) -> None:
-    """Test _start_observing cancels old tasks before creating new ones."""
-    coordinator = _make_coordinator(hass)
-    old_observe = MagicMock()
-    old_watchdog = MagicMock()
-    coordinator._observe_task = old_observe
-    coordinator._watchdog_task = old_watchdog
-
-    def _fake_create_task(coro, *_args, **_kwargs):
-        coro.close()
-        return MagicMock()
-
-    with patch.object(hass, "async_create_background_task", side_effect=_fake_create_task) as create_task:
-        coordinator._start_observing()
-
-    old_observe.cancel.assert_called_once()
-    old_watchdog.cancel.assert_called_once()
-    assert create_task.call_count == 2
-
-
-async def test_start_observing_without_existing_tasks(hass: HomeAssistant) -> None:
-    """Test _start_observing path when no previous tasks exist."""
+async def test_start_observing_is_noop_in_polling_mode(hass: HomeAssistant) -> None:
+    """Test the legacy observe hook remains a no-op."""
     coordinator = _make_coordinator(hass)
 
-    def _fake_create_task(coro, *_args, **_kwargs):
-        coro.close()
-        return MagicMock()
+    coordinator._start_observing()
 
-    with patch.object(hass, "async_create_background_task", side_effect=_fake_create_task) as create_task:
-        coordinator._start_observing()
-
-    assert create_task.call_count == 2
-
-
-async def test_async_observe_status_cancelled_raises(hass: HomeAssistant) -> None:
-    """Test observe loop propagates cancellation."""
-    client = MagicMock()
-
-    async def cancelled_stream():
-        raise asyncio.CancelledError
-        yield {}
-
-    client.observe_status = MagicMock(return_value=cancelled_stream())
-    coordinator = _make_coordinator(hass)
-    coordinator.client = client
-    coordinator._shutting_down = True
-
-    with pytest.raises(asyncio.CancelledError):
-        await coordinator._async_observe_status()
-
-
-async def test_async_observe_status_error_triggers_reconnect(hass: HomeAssistant) -> None:
-    """Test observe loop errors schedule reconnect task."""
-    client = MagicMock()
-
-    async def failing_stream():
-        msg = "stream failed"
-        raise RuntimeError(msg)
-        yield {}
-
-    client.observe_status = MagicMock(return_value=failing_stream())
-    coordinator = _make_coordinator(hass, client=client)
-
-    def _fake_create_task(coro, *_args, **_kwargs):
-        coro.close()
-        return MagicMock()
-
-    with (
-        patch.object(coordinator, "_async_reconnect", new=AsyncMock()) as reconnect_mock,
-        patch.object(hass, "async_create_background_task", side_effect=_fake_create_task) as create_task,
-    ):
-        await coordinator._async_observe_status()
-
-    reconnect_mock.assert_called_once()
-    create_task.assert_called_once()
-
-
-async def test_async_watchdog_triggers_reconnect_when_elapsed(hass: HomeAssistant) -> None:
-    """Test watchdog reconnects when updates are overdue."""
-    coordinator = _make_coordinator(hass)
-    coordinator._timeout = 1
-    coordinator._last_update = 1
-
-    fake_loop = MagicMock()
-    fake_loop.time.return_value = 10
-
-    with (
-        patch(
-            "custom_components.philips_airpurifier.coordinator.asyncio.sleep",
-            side_effect=[None, asyncio.CancelledError],
-        ),
-        patch("custom_components.philips_airpurifier.coordinator.asyncio.get_event_loop", return_value=fake_loop),
-        patch.object(coordinator, "_async_reconnect", new=AsyncMock()) as reconnect_mock,
-    ):
-        with pytest.raises(asyncio.CancelledError):
-            await coordinator._async_watchdog()
-
-    reconnect_mock.assert_awaited_once()
-
-
-async def test_async_watchdog_no_reconnect_when_recent(hass: HomeAssistant) -> None:
-    """Test watchdog does not reconnect when updates are recent."""
-    coordinator = _make_coordinator(hass)
-    coordinator._timeout = 10
-    coordinator._last_update = 100
-
-    fake_loop = MagicMock()
-    fake_loop.time.return_value = 101
-
-    with (
-        patch(
-            "custom_components.philips_airpurifier.coordinator.asyncio.sleep",
-            side_effect=[None, asyncio.CancelledError],
-        ),
-        patch("custom_components.philips_airpurifier.coordinator.asyncio.get_event_loop", return_value=fake_loop),
-        patch.object(coordinator, "_async_reconnect", new=AsyncMock()) as reconnect_mock,
-    ):
-        with pytest.raises(asyncio.CancelledError):
-            await coordinator._async_watchdog()
-
-    reconnect_mock.assert_not_awaited()
-
-
-async def test_async_reconnect_inflight_guard(hass: HomeAssistant) -> None:
-    """Test _async_reconnect returns when reconnect task already running."""
-    coordinator = _make_coordinator(hass)
-    in_flight = MagicMock()
-    in_flight.done.return_value = False
-    coordinator._reconnect_task = in_flight
-
-    with patch.object(hass, "async_create_background_task", return_value=MagicMock()) as create_task:
-        await coordinator._async_reconnect()
-
-    create_task.assert_not_called()
-
-
-async def test_do_reconnect_handles_status_fetch_failure(hass: HomeAssistant) -> None:
-    """Test reconnect continues even when status fetch after reconnect fails."""
-    old_client = AsyncMock()
-    old_client.shutdown = AsyncMock()
-    coordinator = _make_coordinator(hass, client=old_client)
-
-    new_client = AsyncMock()
-    new_client.get_status.side_effect = RuntimeError("status failed")
-
-    with (
-        patch(
-            "custom_components.philips_airpurifier.coordinator.CoAPClient.create",
-            new=AsyncMock(return_value=new_client),
-        ),
-        patch.object(coordinator, "_start_observing") as start_observing,
-    ):
-        await coordinator._do_reconnect()
-
-    start_observing.assert_called_once()
-
-
-async def test_do_reconnect_generic_failure_suppressed(hass: HomeAssistant) -> None:
-    """Test reconnect logs and suppresses non-cancelled failures."""
-    coordinator = _make_coordinator(hass, client=AsyncMock())
-
-    with patch(
-        "custom_components.philips_airpurifier.coordinator.CoAPClient.create",
-        new=AsyncMock(side_effect=RuntimeError("connect failed")),
-    ):
-        await coordinator._do_reconnect()
-
-
-async def test_do_reconnect_cancelled_propagates(hass: HomeAssistant) -> None:
-    """Test reconnect cancellation is propagated."""
-    coordinator = _make_coordinator(hass, client=AsyncMock())
-
-    with (
-        patch(
-            "custom_components.philips_airpurifier.coordinator.CoAPClient.create",
-            new=AsyncMock(side_effect=asyncio.CancelledError),
-        ),
-        pytest.raises(asyncio.CancelledError),
-    ):
-        await coordinator._do_reconnect()
+    assert coordinator.update_interval == timedelta(seconds=DEFAULT_POLL_INTERVAL)
 
 
 async def test_first_refresh_and_observe_raises_not_ready(hass: HomeAssistant) -> None:
     """Test initial refresh failure raises ConfigEntryNotReady."""
-    client = AsyncMock()
-    client.get_status.side_effect = RuntimeError("offline")
-    coordinator = _make_coordinator(hass, client=client)
+    create_client = AsyncMock(side_effect=RuntimeError("offline"))
+    coordinator = _make_coordinator(hass)
+    coordinator._create_client = create_client
 
     with pytest.raises(ConfigEntryNotReady):
         await coordinator.async_first_refresh_and_observe()
 
 
-async def test_shutdown_suppresses_client_shutdown_exception(hass: HomeAssistant) -> None:
-    """Test async_shutdown suppresses client shutdown exceptions."""
+async def test_first_refresh_uses_cached_status_when_device_offline(hass: HomeAssistant) -> None:
+    """Test setup can continue from cached status while polling recovers."""
+    device_info = DeviceInformation(
+        model=TEST_MODEL,
+        name=TEST_NAME,
+        device_id=TEST_DEVICE_ID,
+        host=TEST_HOST,
+    )
+    coordinator = PhilipsAirPurifierCoordinator(
+        hass,
+        TEST_HOST,
+        device_info,
+        initial_status=MOCK_STATUS_GEN1.copy(),
+        create_client=AsyncMock(side_effect=RuntimeError("offline")),
+    )
+
+    with patch.object(hass, "async_create_background_task", return_value=MagicMock()) as create_task:
+        await coordinator.async_first_refresh_and_observe()
+
+    assert coordinator.data == MOCK_STATUS_GEN1
+    assert coordinator.last_update_success is False
+    create_task.assert_called_once()
+
+
+async def test_first_refresh_and_observe_success(hass: HomeAssistant) -> None:
+    """Test initial refresh stores data in polling mode."""
     client = AsyncMock()
-    client.shutdown.side_effect = RuntimeError("ignore")
+    client.get_status = AsyncMock(return_value=({"pwr": "1"}, 30))
+    client.shutdown = AsyncMock()
     coordinator = _make_coordinator(hass, client=client)
 
-    await coordinator.async_shutdown()
+    await coordinator.async_first_refresh_and_observe()
 
-
-async def test_async_observe_status_success_updates_data(hass: HomeAssistant) -> None:
-    """Test observe stream updates coordinator data and timestamp."""
-
-    async def stream():
-        yield {"pwr": "1"}
-
-    client = MagicMock()
-    client.observe_status = MagicMock(return_value=stream())
-    coordinator = _make_coordinator(hass, client=client)
-
-    fake_loop = MagicMock()
-    fake_loop.time.return_value = 123.0
-
-    def _fake_create_task(coro, *_args, **_kwargs):
-        coro.close()
-        return MagicMock()
-
-    with (
-        patch("custom_components.philips_airpurifier.coordinator.asyncio.get_event_loop", return_value=fake_loop),
-        patch.object(hass, "async_create_background_task", side_effect=_fake_create_task),
-    ):
-        await coordinator._async_observe_status()
-
-    assert coordinator._last_update == 123.0
     assert coordinator.data == {"pwr": "1"}
+    assert coordinator.update_interval == timedelta(seconds=30)
 
 
-async def test_async_reconnect_creates_task_when_idle(hass: HomeAssistant) -> None:
-    """Test reconnect schedules reconnect task when none is running."""
-    coordinator = _make_coordinator(hass)
-
-    def _fake_create_task(coro, *_args, **_kwargs):
-        coro.close()
-        return MagicMock()
-
-    with patch.object(hass, "async_create_background_task", side_effect=_fake_create_task) as create_task:
-        await coordinator._async_reconnect()
-
-    create_task.assert_called_once()
+def test_poll_interval_from_timeout_bounds_values() -> None:
+    """Test CoAP max-age values are clamped to safe polling bounds."""
+    assert _poll_interval_from_timeout(1) == timedelta(seconds=MIN_POLL_INTERVAL)
+    assert _poll_interval_from_timeout(45) == timedelta(seconds=45)
+    assert _poll_interval_from_timeout(999) == timedelta(seconds=MAX_POLL_INTERVAL)
+    assert _poll_interval_from_timeout("bad") == timedelta(seconds=DEFAULT_POLL_INTERVAL)
 
 
-async def test_async_shutdown_with_none_client(hass: HomeAssistant) -> None:
-    """Test shutdown handles missing client gracefully."""
-    coordinator = _make_coordinator(hass)
-    coordinator.client = None
-    coordinator._observe_task = None
-    coordinator._watchdog_task = None
-    coordinator._reconnect_task = None
+async def test_control_false_result_raises(hass: HomeAssistant) -> None:
+    """Test a rejected control update is treated as a failure."""
+    client = AsyncMock()
+    client.set_control_values = AsyncMock(return_value=False)
+    client.shutdown = AsyncMock()
+    coordinator = _make_coordinator(hass, client=client)
 
-    await coordinator.async_shutdown()
-
-
-async def test_async_watchdog_skips_elapsed_check_when_no_last_update(hass: HomeAssistant) -> None:
-    """Test watchdog branch where _last_update is zero."""
-    coordinator = _make_coordinator(hass)
-    coordinator._timeout = 1
-    coordinator._last_update = 0
-
-    with (
-        patch(
-            "custom_components.philips_airpurifier.coordinator.asyncio.sleep",
-            side_effect=[None, asyncio.CancelledError],
-        ),
-        patch.object(coordinator, "_async_reconnect", new=AsyncMock()) as reconnect_mock,
-    ):
-        with pytest.raises(asyncio.CancelledError):
-            await coordinator._async_watchdog()
-
-    reconnect_mock.assert_not_awaited()
+    with pytest.raises(RuntimeError, match="rejected"):
+        await coordinator.async_set_control_values({"pwr": "1"})
 
 
-async def test_async_reconnect_done_task_creates_new_task(hass: HomeAssistant) -> None:
-    """Test reconnect schedules when previous reconnect task is done."""
-    coordinator = _make_coordinator(hass)
-    done_task = MagicMock()
-    done_task.done.return_value = True
-    coordinator._reconnect_task = done_task
+async def test_control_refresh_is_scheduled(hass: HomeAssistant) -> None:
+    """Test successful controls request a follow-up status refresh."""
+    client = AsyncMock()
+    client.set_control_values = AsyncMock(return_value=True)
+    client.shutdown = AsyncMock()
+    coordinator = _make_coordinator(hass, client=client)
+    coordinator.async_set_updated_data({"pwr": "0"})
 
-    def _fake_create_task(coro, *_args, **_kwargs):
-        coro.close()
-        return MagicMock()
-
-    with patch.object(hass, "async_create_background_task", side_effect=_fake_create_task) as create_task:
-        await coordinator._async_reconnect()
+    with patch.object(hass, "async_create_background_task", return_value=MagicMock()) as create_task:
+        await coordinator.async_set_control_values({"pwr": "1"})
 
     create_task.assert_called_once()
-
-
-async def test_do_reconnect_success_updates_data_and_timeout(hass: HomeAssistant) -> None:
-    """Test reconnect success path updates coordinator state and restarts observe."""
-    old_client = AsyncMock()
-    old_client.shutdown = AsyncMock()
-    coordinator = _make_coordinator(hass, client=old_client)
-
-    new_status = {"pwr": "1", "pm25": 5}
-    new_client = AsyncMock()
-    new_client.get_status = AsyncMock(return_value=(new_status, 45))
-
-    with (
-        patch(
-            "custom_components.philips_airpurifier.coordinator.CoAPClient.create",
-            new=AsyncMock(return_value=new_client),
-        ),
-        patch.object(coordinator, "_start_observing") as start_observing,
-    ):
-        await coordinator._do_reconnect()
-
-    assert coordinator.data == new_status
-    assert coordinator._timeout == 45
-    start_observing.assert_called_once()
-
-
-async def test_async_shutdown_cancels_all_existing_tasks(hass: HomeAssistant) -> None:
-    """Test shutdown cancels observe/watchdog/reconnect tasks when present."""
-    coordinator = _make_coordinator(hass)
-
-    async def _block_forever():
-        await asyncio.Event().wait()
-
-    observe_task = hass.async_create_task(_block_forever())
-    watchdog_task = hass.async_create_task(_block_forever())
-    reconnect_task = hass.async_create_task(_block_forever())
-    coordinator._observe_task = observe_task
-    coordinator._watchdog_task = watchdog_task
-    coordinator._reconnect_task = reconnect_task
-    coordinator.client = AsyncMock()
-
-    await coordinator.async_shutdown()
-
-    assert observe_task.cancelled()
-    assert watchdog_task.cancelled()
-    assert reconnect_task.cancelled()
-    assert coordinator._shutting_down is True
-    assert coordinator._observe_task is None
-    assert coordinator._watchdog_task is None
-    assert coordinator._reconnect_task is None


### PR DESCRIPTION
## Summary

- replace the long-lived CoAP observe stream with bounded polling that creates a fresh client per status/control operation
- add explicit timeouts, status retries, and cached-status startup so Home Assistant can load entities while the purifier is temporarily offline
- update diagnostics/repair health checks and add a PowerShell monitor script for live HA verification
- fix invalid Python exception syntax in sensor icon handling

## Root Cause

The integration depended on a long-lived aiocoap observation stream. When the Philips device firmware or UDP connection stopped responding, the shared client/observe task could stall setup or recovery. The new path isolates each request so a bad CoAP exchange times out and the next poll starts cleanly.

## Validation

- `python -m py_compile` on the modified integration files
- deployed to a Home Assistant 2026.5.4 instance via Samba
- restarted Home Assistant and verified the config entry loads
- monitor script observed the purifier recover to `unavailable=0`, `fan=on`, PM2.5 readings, and RSSI updates

## Notes

The default polling interval is 60 seconds and is clamped between 30 and 300 seconds based on the device CoAP max-age value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Switched to bounded local polling with clamped intervals based on device max-age; retry and recovery for unavailable devices.
  * Temporary client usage with improved timeouts, safe shutdown, and follow-up status refresh after control commands.

* **Bug Fixes**
  * More reliable connectivity detection and repair handling; control errors now mark devices unavailable appropriately.

* **Documentation**
  * README updated to document local polling model and troubleshooting.

* **Other**
  * Integration version bumped to 2026.4.3.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ruaan-deysel/ha-philips-airpurifier/pull/31?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->