### PR TITLE
Latest-HA dev container, issue #29/#26/#8 fixes, notification event entity, philips-airctrl 1.1.0

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+
+  "enabledPlugins": {
+    "superpowers-extended-cc@superpowers-extended-cc-marketplace": true
+  },
+
+  "cleanupPeriodDays": 365,
+
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  },
+
+  "env": {
+    "CLAUDE_CODE_TERMINAL_OUTPUT_MAX_LENGTH": "150000",
+    "CLAUDE_CODE_MAX_FILE_READ_TOKENS": "100000",
+    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "75",
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "DISABLE_TELEMETRY": "1",
+    "DISABLE_ERROR_REPORTING": "1",
+    "DISABLE_BUG_COMMAND": "1"
+  },
+
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "INPUT=$(cat); FILE=$(echo \"$INPUT\" | jq -r '.tool_input.file_path'); LIMIT=$(echo \"$INPUT\" | jq -r '.tool_input.limit // empty'); if [ -n \"$LIMIT\" ]; then exit 0; fi; if [ -f \"$FILE\" ]; then LINES=$(wc -l < \"$FILE\"); if [ \"$LINES\" -gt 2000 ]; then printf '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"WARNING: This file has %d lines which exceeds the 2000-line default. Use offset and limit parameters to read in chunks.\"}}\n' \"$LINES\"; exit 2; fi; fi",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,11 @@
 version: 2
 updates:
-  - package-ecosystem: "pip"
+  # Python dependencies (uv project: pyproject.toml + uv.lock).
+  # Checked daily so the Home Assistant floor tracks new stable releases quickly.
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
     open-pull-requests-limit: 10
     groups:
       homeassistant:
@@ -16,6 +17,22 @@ updates:
         update-types:
           - "minor"
           - "patch"
+
+  # Dev container base image (mcr.microsoft.com/devcontainers/python).
+  - package-ecosystem: "docker"
+    directory: "/.devcontainer"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+
+  # Dev container features (devcontainer.json), if any are added later.
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/custom_components/philips_airpurifier/__init__.py
+++ b/custom_components/philips_airpurifier/__init__.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.typing import ConfigType
 from .client import async_create_client
 from .const import (
     CONF_DEVICE_ID,
+    CONF_MAC,
     CONF_MODEL,
     CONF_STATUS,
     DOMAIN,
@@ -32,6 +33,7 @@ type PhilipsAirPurifierConfigEntry = ConfigEntry[PhilipsAirPurifierCoordinator]
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.CLIMATE,
+    Platform.EVENT,
     Platform.FAN,
     Platform.HUMIDIFIER,
     Platform.LIGHT,
@@ -74,7 +76,7 @@ async def async_setup_entry(
 
     device_information = DeviceInformation(
         host=host,
-        mac=None,
+        mac=entry.data.get(CONF_MAC),
         model=model,
         name=name,
         device_id=device_id,

--- a/custom_components/philips_airpurifier/client.py
+++ b/custom_components/philips_airpurifier/client.py
@@ -25,10 +25,14 @@ async def async_fetch_status(
     status_timeout: float = 30,
     create_client: Any | None = None,
 ) -> dict[str, Any]:
-    """Fetch current status using a temporary CoAP client and shut it down."""
+    """Fetch current status using a temporary CoAP client and shut it down.
+
+    Uses ``observe=False`` (philips-airctrl >= 1.1.0) so this one-shot read does
+    not leave a CoAP observation registered on the device.
+    """
     client = await async_create_client(host, timeout=connect_timeout, create_client=create_client)
     try:
-        status, _ = await asyncio.wait_for(client.get_status(), timeout=status_timeout)
+        status, _ = await asyncio.wait_for(client.get_status(observe=False), timeout=status_timeout)
         return status
     finally:
         with contextlib.suppress(Exception):

--- a/custom_components/philips_airpurifier/config_flow.py
+++ b/custom_components/philips_airpurifier/config_flow.py
@@ -12,10 +12,11 @@ from homeassistant import config_entries, exceptions
 from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from .client import async_fetch_status
-from .const import CONF_DEVICE_ID, CONF_MODEL, CONF_STATUS, DOMAIN, PhilipsApi
+from .const import CONF_DEVICE_ID, CONF_MAC, CONF_MODEL, CONF_STATUS, DOMAIN, PhilipsApi
 from .device_models import DEVICE_MODELS
 from .helpers import extract_model, extract_name
 
@@ -41,6 +42,7 @@ class PhilipsAirPurifierConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     def __init__(self) -> None:
         """Initialize."""
         self._host: str | None = None
+        self._mac: str | None = None
         self._model: Any = None
         self._name: Any = None
         self._device_id: str | None = None
@@ -81,7 +83,11 @@ class PhilipsAirPurifierConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         _LOGGER.debug("async_step_dhcp: called, found: %s", discovery_info)
 
         self._host = discovery_info.ip
-        _LOGGER.debug("trying to configure host: %s", self._host)
+        # Capture the MAC so the device is registered with a network-MAC
+        # connection, enabling DHCP re-discovery after an IP change (issue #8).
+        if discovery_info.macaddress:
+            self._mac = format_mac(discovery_info.macaddress)
+        _LOGGER.debug("trying to configure host: %s (mac: %s)", self._host, self._mac)
 
         # let's try and connect to an AirPurifier
         try:
@@ -151,9 +157,14 @@ class PhilipsAirPurifierConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         unique_id = self._device_id
         _LOGGER.debug("async_step_user: unique_id=%s", unique_id)
 
-        # set the unique id for the entry, abort if it already exists
+        # set the unique id for the entry, abort if it already exists.
+        # Update the stored host (and MAC) so a re-discovered device with a new
+        # IP keeps working instead of erroring out (issue #8).
         await self.async_set_unique_id(unique_id)
-        self._abort_if_unique_id_configured(updates={CONF_HOST: self._host})
+        updates: dict[str, Any] = {CONF_HOST: self._host}
+        if self._mac:
+            updates[CONF_MAC] = self._mac
+        self._abort_if_unique_id_configured(updates=updates)
 
         # store the data for the next step to get confirmation
         self.context.update(
@@ -185,6 +196,8 @@ class PhilipsAirPurifierConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             user_input[CONF_DEVICE_ID] = self._device_id
             user_input[CONF_HOST] = self._host
             user_input[CONF_STATUS] = self._status
+            if self._mac:
+                user_input[CONF_MAC] = self._mac
 
             config_entry_name = f"{self._model} {self._name}"
 

--- a/custom_components/philips_airpurifier/const.py
+++ b/custom_components/philips_airpurifier/const.py
@@ -47,6 +47,15 @@ DEFAULT_NAME = "Philips AirPurifier"
 CONF_MODEL = "model"
 CONF_DEVICE_ID = "device_id"
 CONF_STATUS = "status"
+# MAC address captured during DHCP discovery. Stored so the device is registered
+# with a network-MAC connection, which lets the `registered_devices` DHCP matcher
+# re-discover the device and update its IP after a DHCP lease change. See issue #8.
+CONF_MAC = "mac"
+
+# Config-entry option flag set when the user acknowledges the filter
+# replacement repair, so it is not recreated on every coordinator update.
+# Reset automatically once a filter reads as freshly replaced. See issue #29.
+OPT_FILTER_WARNING_ACK = "filter_warning_acknowledged"
 
 SWITCH_ON = "on"
 TEST_ON = "on"
@@ -77,6 +86,7 @@ class FanModel(StrEnum):
     AC0951 = "AC0951"
     AC1214 = "AC1214"
     AC1715 = "AC1715"
+    AC2221 = "AC2221"
     AC2729 = "AC2729"
     AC2889 = "AC2889"
     AC2936 = "AC2936"
@@ -551,9 +561,13 @@ SENSOR_TYPES: dict[str, SensorDescription] = {
         ATTR_STATE_CLASS: SensorStateClass.MEASUREMENT,
     },
     PhilipsApi.TOTAL_VOLATILE_ORGANIC_COMPOUNDS: {
-        ATTR_DEVICE_CLASS: SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
+        # The Philips "tvoc" value is an air-quality level/index, not a mass
+        # concentration, so it must NOT use the volatile_organic_compounds
+        # device class (which mandates µg/m³ or mg/m³ and otherwise logs a
+        # validation warning on every state update). See issue #29.
         FanAttributes.LABEL: FanAttributes.TOTAL_VOLATILE_ORGANIC_COMPOUNDS,
         ATTR_STATE_CLASS: SensorStateClass.MEASUREMENT,
+        FanAttributes.ICON_MAP: {0: "mdi:blur"},
     },
     PhilipsApi.HUMIDITY: {
         ATTR_DEVICE_CLASS: SensorDeviceClass.HUMIDITY,

--- a/custom_components/philips_airpurifier/coordinator.py
+++ b/custom_components/philips_airpurifier/coordinator.py
@@ -86,6 +86,11 @@ class PhilipsAirPurifierCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         return self.device_info.name
 
     @property
+    def mac(self) -> str | None:
+        """Return the device MAC address, if known (from DHCP discovery)."""
+        return self.device_info.mac
+
+    @property
     def model_config(self) -> DeviceModelConfig:
         """Return the device model configuration."""
         model = self.device_info.model

--- a/custom_components/philips_airpurifier/coordinator.py
+++ b/custom_components/philips_airpurifier/coordinator.py
@@ -112,7 +112,9 @@ class PhilipsAirPurifierCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from the device (used for initial refresh and fallback)."""
         try:
-            status, timeout = await self.client.get_status()
+            # One-shot read: ongoing updates come from the observe stream, so
+            # avoid registering a redundant observation (philips-airctrl >= 1.1.0).
+            status, timeout = await self.client.get_status(observe=False)
             self._timeout = timeout
             self._mark_available()
             return status
@@ -196,7 +198,8 @@ class PhilipsAirPurifierCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             _LOGGER.info("Reconnected to %s", self.host)
 
             try:
-                status, timeout = await self.client.get_status()
+                # One-shot read before re-establishing the observe stream.
+                status, timeout = await self.client.get_status(observe=False)
                 self._timeout = timeout
                 self._mark_available()
                 self.async_set_updated_data(status)
@@ -216,7 +219,9 @@ class PhilipsAirPurifierCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     async def async_first_refresh_and_observe(self) -> None:
         """Perform first refresh and start observing."""
         try:
-            status, timeout = await self.client.get_status()
+            # One-shot initial read; continuous updates come from the observe
+            # stream started below, so don't register a second observation here.
+            status, timeout = await self.client.get_status(observe=False)
             self._timeout = timeout
             self._mark_available()
             self.async_set_updated_data(status)

--- a/custom_components/philips_airpurifier/device_models.py
+++ b/custom_components/philips_airpurifier/device_models.py
@@ -582,6 +582,26 @@ _CONFIG_AC32XX = DeviceModelConfig(
     ],
 )
 
+# AC2221 config (PureProtect Quiet 2200 series, e.g. AC2221/13).
+# Gen3 "Combo" purifier with PM2.5 + allergen index, lamp/ambient light and the
+# NEW2 preferred-index select. No humidifier and no gas sensor. See issue #26.
+_CONFIG_AC2221 = DeviceModelConfig(
+    api_generation=ApiGeneration.GEN3,
+    preset_modes=_AC32XX_PRESET_MODES,
+    speeds=_AC32XX_SPEEDS,
+    lights=[PhilipsApi.NEW2_DISPLAY_BACKLIGHT3],
+    switches=[
+        PhilipsApi.NEW2_CHILD_LOCK,
+        PhilipsApi.NEW2_BEEP,
+        PhilipsApi.NEW2_AUTO_PLUS_AI,
+    ],
+    selects=[
+        PhilipsApi.NEW2_PREFERRED_INDEX,
+        PhilipsApi.NEW2_LAMP_MODE,
+        PhilipsApi.NEW2_AMBIENT_LIGHT_MODE,
+    ],
+)
+
 # AC3210/AC3220/AC3221 config (overrides selects from AC32xx)
 _CONFIG_AC3210 = DeviceModelConfig(
     api_generation=ApiGeneration.GEN3,
@@ -784,6 +804,10 @@ DEVICE_MODELS: dict[str, DeviceModelConfig] = {
         # selects from PhilipsNewGenericFan: [NEW_PREFERRED_INDEX]
         selects=[PhilipsApi.NEW_PREFERRED_INDEX],
     ),
+    # =========================================================================
+    # AC2221 family (PureProtect Quiet 2200 series, e.g. AC2221/13)
+    # =========================================================================
+    FanModel.AC2221: _CONFIG_AC2221,
     # =========================================================================
     # AC2729
     # =========================================================================

--- a/custom_components/philips_airpurifier/entity.py
+++ b/custom_components/philips_airpurifier/entity.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo, format_mac
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
@@ -22,8 +22,13 @@ class PhilipsAirPurifierEntity(CoordinatorEntity[PhilipsAirPurifierCoordinator])
     ) -> None:
         """Initialize the entity."""
         super().__init__(coordinator)
+        # Register the network MAC connection when known (captured during DHCP
+        # discovery) so Home Assistant can re-discover the device and update its
+        # IP via the `registered_devices` DHCP matcher after a lease change.
+        connections = {(CONNECTION_NETWORK_MAC, format_mac(coordinator.mac))} if coordinator.mac else set()
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, coordinator.device_id)},
+            connections=connections,
             name=coordinator.device_name,
             manufacturer="Philips",
             model=coordinator.model,

--- a/custom_components/philips_airpurifier/event.py
+++ b/custom_components/philips_airpurifier/event.py
@@ -1,0 +1,106 @@
+"""Philips Air Purifier event platform.
+
+Exposes device notifications (error / warning codes reported by the purifier) as
+a Home Assistant event entity. The entity reads the status published by the
+``philips-airctrl`` library through the coordinator; it never talks to the
+device directly.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components.event import EventEntity
+from homeassistant.const import EntityCategory
+from homeassistant.core import callback
+
+from .const import PhilipsApi
+from .entity import PhilipsAirPurifierEntity
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+    from .__init__ import PhilipsAirPurifierConfigEntry
+    from .coordinator import PhilipsAirPurifierCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+PARALLEL_UPDATES = 0
+
+# Status keys that carry a device error/notification code, across API
+# generations. The first key present in the status payload is used.
+_ERROR_CODE_KEYS: tuple[str, ...] = (
+    PhilipsApi.ERROR_CODE,  # Gen1 "err"
+    PhilipsApi.NEW2_ERROR_CODE,  # Gen3 "D03240"
+)
+
+# Out-of-water is encoded in bit 9 of the error code on the models that report
+# it; surfacing it as a distinct event makes automations easier to write.
+_OUT_OF_WATER_BIT = 1 << 8
+
+EVENT_ERROR = "error"
+EVENT_OUT_OF_WATER = "out_of_water"
+EVENT_CLEARED = "cleared"
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: PhilipsAirPurifierConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the event platform."""
+    coordinator = entry.runtime_data
+    status = coordinator.data or {}
+
+    if any(key in status for key in _ERROR_CODE_KEYS):
+        async_add_entities([PhilipsNotificationEvent(coordinator)])
+
+
+class PhilipsNotificationEvent(PhilipsAirPurifierEntity, EventEntity):
+    """Event entity that fires when the device raises or clears a notification."""
+
+    _attr_translation_key = "notification"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_event_types = [EVENT_ERROR, EVENT_OUT_OF_WATER, EVENT_CLEARED]
+
+    def __init__(self, coordinator: PhilipsAirPurifierCoordinator) -> None:
+        """Initialize the notification event entity."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.model}-{coordinator.device_id}-notification"
+        # Seeded on the first refresh so an already-present code at startup does
+        # not fire a spurious event.
+        self._last_code: int | None = None
+
+    def _read_code(self) -> tuple[str | None, int]:
+        """Return the active error-code key and its integer value."""
+        status = self._device_status or {}
+        for key in _ERROR_CODE_KEYS:
+            if key in status:
+                try:
+                    return key, int(status[key])
+                except TypeError, ValueError:
+                    return key, 0
+        return None, 0
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Fire an event when the device's notification code changes."""
+        source_key, code = self._read_code()
+
+        if self._last_code is None:
+            # First update after startup: record the baseline without firing.
+            self._last_code = code
+        elif code != self._last_code:
+            details: dict[str, Any] = {"code": code, "source": source_key}
+            if code == 0:
+                event_type = EVENT_CLEARED
+            elif code & _OUT_OF_WATER_BIT:
+                event_type = EVENT_OUT_OF_WATER
+            else:
+                event_type = EVENT_ERROR
+            self._trigger_event(event_type, details)
+            self._last_code = code
+
+        super()._handle_coordinator_update()

--- a/custom_components/philips_airpurifier/manifest.json
+++ b/custom_components/philips_airpurifier/manifest.json
@@ -29,5 +29,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ruaan-deysel/ha-philips-airpurifier/issues",
   "requirements": ["philips-airctrl==1.1.0"],
-  "version": "2026.05.0"
+  "version": "2026.5.0"
 }

--- a/custom_components/philips_airpurifier/manifest.json
+++ b/custom_components/philips_airpurifier/manifest.json
@@ -29,5 +29,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ruaan-deysel/ha-philips-airpurifier/issues",
   "requirements": ["philips-airctrl==1.0.0"],
-  "version": "2026.4.1"
+  "version": "2026.05.0"
 }

--- a/custom_components/philips_airpurifier/manifest.json
+++ b/custom_components/philips_airpurifier/manifest.json
@@ -28,6 +28,6 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ruaan-deysel/ha-philips-airpurifier/issues",
-  "requirements": ["philips-airctrl==1.0.0"],
+  "requirements": ["philips-airctrl==1.1.0"],
   "version": "2026.05.0"
 }

--- a/custom_components/philips_airpurifier/repairs.py
+++ b/custom_components/philips_airpurifier/repairs.py
@@ -14,7 +14,7 @@ from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import device_registry as dr, entity_registry as er, issue_registry as ir
 
 from .client import async_fetch_status
-from .const import CONF_STATUS, DOMAIN
+from .const import CONF_STATUS, DOMAIN, OPT_FILTER_WARNING_ACK
 
 if TYPE_CHECKING:
     from .coordinator import PhilipsAirPurifierCoordinator
@@ -33,7 +33,7 @@ async def async_create_fix_flow(
     if issue_id == "entity_registry_cleanup":
         return EntityRegistryCleanupFlow()
     if issue_id == "filter_replacement_warning":
-        return FilterReplacementWarningFlow()
+        return FilterReplacementWarningFlow(data)
     if issue_id == "configuration_migration":
         return ConfigurationMigrationFlow()
     if issue_id == "duplicate_entities":
@@ -188,6 +188,10 @@ class EntityRegistryCleanupFlow(RepairsFlow):
 class FilterReplacementWarningFlow(RepairsFlow):
     """Handler for filter replacement warnings."""
 
+    def __init__(self, data: dict[str, str | int | float | None] | None = None) -> None:
+        """Store the issue data so we can locate the config entry."""
+        self._data = data or {}
+
     async def async_step_init(self, user_input: dict[str, str] | None = None) -> FlowResult:
         """Handle the initial step."""
         if user_input is not None:
@@ -205,7 +209,23 @@ class FilterReplacementWarningFlow(RepairsFlow):
         )
 
     async def async_step_acknowledge_warning(self) -> FlowResult:
-        """Acknowledge the filter warning."""
+        """Acknowledge the filter warning and stop it from reappearing.
+
+        The acknowledgment is persisted in the config entry options so the
+        periodic health check does not recreate the issue on the next
+        coordinator update. It is reset automatically once a filter reads as
+        freshly replaced (see ``async_check_integration_health``).
+        """
+        entry_id = self._data.get("entry_id")
+        if entry_id:
+            entry = self.hass.config_entries.async_get_entry(str(entry_id))
+            if entry is not None:
+                self.hass.config_entries.async_update_entry(
+                    entry,
+                    options={**entry.options, OPT_FILTER_WARNING_ACK: True},
+                )
+
+        async_delete_issue(self.hass, "filter_replacement_warning")
         return self.async_create_entry(title="Filter Warning Acknowledged", data={"result": "warning_acknowledged"})
 
 
@@ -395,15 +415,32 @@ async def async_check_integration_health(
                     filter_warning_needed = True
                     break
 
+    # Locate the config entry for this coordinator so the warning can be
+    # acknowledged persistently and reset once a filter is replaced (issue #29).
+    entry = next(
+        (e for e in hass.config_entries.async_entries(DOMAIN) if e.data.get(CONF_HOST) == coordinator.host),
+        None,
+    )
+    acknowledged = bool(entry and entry.options.get(OPT_FILTER_WARNING_ACK, False))
+
     if filter_warning_needed:
-        async_create_issue(
-            hass,
-            "filter_replacement_warning",
-            "filter_replacement_warning",
-            severity=ir.IssueSeverity.WARNING,
-        )
+        # Only (re)create the issue if the user has not already acknowledged it,
+        # otherwise it would reappear on the next coordinator update.
+        if not acknowledged:
+            async_create_issue(
+                hass,
+                "filter_replacement_warning",
+                "filter_replacement_warning",
+                severity=ir.IssueSeverity.WARNING,
+                data={"entry_id": entry.entry_id} if entry else None,
+            )
     else:
         async_delete_issue(hass, "filter_replacement_warning")
+        # Filters are healthy again (e.g. replaced): clear the acknowledgment so
+        # a future low-filter condition surfaces a fresh warning.
+        if acknowledged and entry is not None:
+            options = {k: v for k, v in entry.options.items() if k != OPT_FILTER_WARNING_ACK}
+            hass.config_entries.async_update_entry(entry, options=options)
 
     # Check for entity registry issues
     entity_registry = er.async_get(hass)

--- a/custom_components/philips_airpurifier/strings.json
+++ b/custom_components/philips_airpurifier/strings.json
@@ -155,6 +155,20 @@
         }
       }
     },
+    "event": {
+      "notification": {
+        "name": "Notification",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "error": "Error",
+              "out_of_water": "Out of water",
+              "cleared": "Cleared"
+            }
+          }
+        }
+      }
+    },
     "sensor": {
       "indoor_allergen_index": {
         "name": "Indoor allergen index"

--- a/custom_components/philips_airpurifier/translations/en.json
+++ b/custom_components/philips_airpurifier/translations/en.json
@@ -158,6 +158,20 @@
         }
       }
     },
+    "event": {
+      "notification": {
+        "name": "Notification",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "error": "Error",
+              "out_of_water": "Out of water",
+              "cleared": "Cleared"
+            }
+          }
+        }
+      }
+    },
     "sensor": {
       "indoor_allergen_index": {
         "name": "Indoor allergen index"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,19 @@ dev = [
     "pytest",
     "pytest-asyncio",
     "pytest-cov",
+    # Linting/formatting and type checking. Required by scripts/lint,
+    # scripts/lint-check, scripts/type-check and the lint CI workflow, which all
+    # invoke `uv run ruff` / `uv run pyright`. ruff is pinned to the
+    # pre-commit-config version to avoid format drift between the two.
+    "ruff==0.15.1",
+    "pyright",
+    # The homeassistant floor keeps the resolver pinned to the latest stable
+    # Home Assistant. Without a floor, `uv lock --upgrade` can resolve backwards
+    # to ancient releases. pytest-homeassistant-custom-component is left
+    # unpinned so the resolver selects the release whose pinned HA matches the
+    # floor (the newest phacc targets pre-release HA). Dependabot (homeassistant
+    # group) bumps the floor on every stable HA release.
+    "homeassistant>=2026.5.4",
     "pytest-homeassistant-custom-component",
 ]
 
@@ -63,7 +76,7 @@ exclude_lines = [
 
 [tool.uv]
 # Security overrides: force patched versions of vulnerable transitive dependencies
-# pinned by homeassistant 2026.4.2 at vulnerable versions.
+# pinned by Home Assistant at vulnerable versions.
 override-dependencies = [
     "pyjwt>=2.12.0",   # CVE-2026-32597
     "uv>=0.11.6",      # GHSA-pjjw-68hj-v9mw

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Home Assistant integration for Philips Air Purifiers via CoAP"
 requires-python = ">=3.14.2"
 license = {text = "MIT"}
 dependencies = [
-    "philips-airctrl==1.0.0",
+    "philips-airctrl==1.1.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/develop
+++ b/scripts/develop
@@ -10,7 +10,7 @@ cd "$(dirname "$0")/.."
 # Create config dir if not present
 if [[ ! -d "${PWD}/config" ]]; then
     mkdir -p "${PWD}/config"
-    hass --config "${PWD}/config" --script ensure_config
+    uv run hass --config "${PWD}/config" --script ensure_config
 fi
 
 # Set the path to custom_components

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,15 +66,32 @@ def mock_coap_client() -> Generator[AsyncMock]:
 
 @pytest.fixture
 def mock_coap_client_config_flow() -> Generator[AsyncMock]:
-    """Return a mocked CoAP client for config flow tests."""
-    with patch(
-        "custom_components.philips_airpurifier.config_flow.CoAPClient",
-    ) as mock_client_cls:
-        client = AsyncMock()
-        client.get_status = AsyncMock(return_value=(MOCK_STATUS_GEN1.copy(), 60))
-        client.shutdown = AsyncMock()
+    """Return a mocked CoAP client for config flow tests.
 
-        mock_client_cls.create = AsyncMock(return_value=client)
+    Patches both the config-flow client and the integration setup client (plus
+    the observe start) so that when a flow creates a config entry, the automatic
+    setup performed by the test harness does not open a real network socket.
+    """
+    client = AsyncMock()
+    client.get_status = AsyncMock(return_value=(MOCK_STATUS_GEN1.copy(), 60))
+    client.set_control_values = AsyncMock()
+    client.set_control_value = AsyncMock()
+    client.shutdown = AsyncMock()
+
+    with (
+        patch(
+            "custom_components.philips_airpurifier.config_flow.CoAPClient",
+        ) as mock_flow_client_cls,
+        patch(
+            "custom_components.philips_airpurifier.CoAPClient",
+        ) as mock_setup_client_cls,
+        patch(
+            "custom_components.philips_airpurifier.coordinator.PhilipsAirPurifierCoordinator._start_observing",
+        ),
+    ):
+        mock_flow_client_cls.create = AsyncMock(return_value=client)
+        mock_setup_client_cls.create = AsyncMock(return_value=client)
+        mock_setup_client_cls.return_value = client
 
         yield client
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -30,6 +30,31 @@ from .const import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _no_real_entry_setup() -> object:
+    """Neutralize the entry setup that the test harness runs after a flow.
+
+    Config-flow tests create real config entries; the harness then sets them up,
+    which would otherwise instantiate a real CoAP client and open a network
+    socket. Patching the integration's client (and the observe start) keeps that
+    automatic setup offline without affecting the flow assertions.
+    """
+    client = AsyncMock()
+    client.get_status = AsyncMock(return_value=(MOCK_STATUS_GEN1.copy(), 60))
+    client.set_control_values = AsyncMock()
+    client.set_control_value = AsyncMock()
+    client.shutdown = AsyncMock()
+    with (
+        patch("custom_components.philips_airpurifier.CoAPClient") as mock_setup_client_cls,
+        patch(
+            "custom_components.philips_airpurifier.coordinator.PhilipsAirPurifierCoordinator._start_observing",
+        ),
+    ):
+        mock_setup_client_cls.create = AsyncMock(return_value=client)
+        mock_setup_client_cls.return_value = client
+        yield
+
+
 async def test_user_flow_success(
     hass: HomeAssistant,
     mock_coap_client_config_flow: AsyncMock,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -125,7 +125,8 @@ async def test_coordinator_async_update_data(
 
     assert result == updated_status
     assert result["pm25"] == 25
-    mock_coap_client.get_status.assert_called_once()
+    # One-shot reads must not register a CoAP observation (philips-airctrl >= 1.1.0).
+    mock_coap_client.get_status.assert_called_once_with(observe=False)
 
 
 async def test_coordinator_async_update_data_error(

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,0 +1,113 @@
+"""Tests for Philips AirPurifier event platform."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from custom_components.philips_airpurifier.const import PhilipsApi
+from custom_components.philips_airpurifier.event import (
+    EVENT_CLEARED,
+    EVENT_ERROR,
+    EVENT_OUT_OF_WATER,
+    PhilipsNotificationEvent,
+    async_setup_entry,
+)
+from homeassistant.core import HomeAssistant
+
+TEST_MODEL = "AC2729"
+TEST_DEVICE_ID = "aabbccddeeff"
+
+
+def _make_event_entity(initial: dict | None = None) -> tuple[PhilipsNotificationEvent, MagicMock]:
+    """Return a notification event entity backed by a mock coordinator."""
+    coordinator = MagicMock()
+    coordinator.model = TEST_MODEL
+    coordinator.device_id = TEST_DEVICE_ID
+    coordinator.device_name = "Living Room"
+    coordinator.mac = None
+    coordinator.data = initial if initial is not None else {}
+
+    entity = PhilipsNotificationEvent(coordinator)
+    # Avoid touching the entity/state machine in these pure unit tests.
+    entity.async_write_ha_state = MagicMock()  # type: ignore[method-assign]
+    return entity, coordinator
+
+
+async def test_setup_adds_entity_when_error_key_present(hass: HomeAssistant) -> None:
+    """The entity is created only when the status exposes an error code key."""
+    coordinator = MagicMock()
+    coordinator.data = {PhilipsApi.ERROR_CODE: 0}
+    coordinator.mac = None
+    entry = MagicMock()
+    entry.runtime_data = coordinator
+    added: list = []
+
+    await async_setup_entry(hass, entry, added.extend)
+    assert len(added) == 1
+    assert isinstance(added[0], PhilipsNotificationEvent)
+
+
+async def test_setup_skips_entity_without_error_key(hass: HomeAssistant) -> None:
+    """No entity is created when the device does not report an error code."""
+    coordinator = MagicMock()
+    coordinator.data = {"pwr": "1"}
+    entry = MagicMock()
+    entry.runtime_data = coordinator
+    added: list = []
+
+    await async_setup_entry(hass, entry, added.extend)
+    assert added == []
+
+
+def test_first_update_seeds_baseline_without_firing() -> None:
+    """The first coordinator update records the code but fires no event."""
+    entity, coordinator = _make_event_entity({PhilipsApi.ERROR_CODE: 49408})
+
+    with patch.object(entity, "_trigger_event") as trigger:
+        entity._handle_coordinator_update()
+
+    trigger.assert_not_called()
+    assert entity._last_code == 49408
+
+
+def test_error_event_fired_on_change() -> None:
+    """A new non-zero, non-water error fires an 'error' event with details."""
+    entity, coordinator = _make_event_entity({PhilipsApi.ERROR_CODE: 0})
+    entity._handle_coordinator_update()  # seed baseline at 0
+
+    coordinator.data = {PhilipsApi.ERROR_CODE: 4}
+    with patch.object(entity, "_trigger_event") as trigger:
+        entity._handle_coordinator_update()
+
+    trigger.assert_called_once_with(EVENT_ERROR, {"code": 4, "source": PhilipsApi.ERROR_CODE})
+
+
+def test_out_of_water_event_fired() -> None:
+    """The out-of-water bit (bit 9) fires a dedicated event."""
+    entity, coordinator = _make_event_entity({PhilipsApi.ERROR_CODE: 0})
+    entity._handle_coordinator_update()
+
+    coordinator.data = {PhilipsApi.ERROR_CODE: 256}  # bit 9 set
+    with patch.object(entity, "_trigger_event") as trigger:
+        entity._handle_coordinator_update()
+
+    trigger.assert_called_once_with(EVENT_OUT_OF_WATER, {"code": 256, "source": PhilipsApi.ERROR_CODE})
+
+
+def test_cleared_event_fired_when_code_returns_to_zero() -> None:
+    """Returning to code 0 fires a 'cleared' event."""
+    entity, coordinator = _make_event_entity({PhilipsApi.ERROR_CODE: 4})
+    entity._handle_coordinator_update()  # baseline 4
+
+    coordinator.data = {PhilipsApi.ERROR_CODE: 0}
+    with patch.object(entity, "_trigger_event") as trigger:
+        entity._handle_coordinator_update()
+
+    trigger.assert_called_once_with(EVENT_CLEARED, {"code": 0, "source": PhilipsApi.ERROR_CODE})
+
+
+def test_non_integer_code_is_treated_as_zero() -> None:
+    """A non-numeric error code is coerced to 0 rather than raising."""
+    entity, coordinator = _make_event_entity({PhilipsApi.ERROR_CODE: "n/a"})
+    entity._handle_coordinator_update()
+    assert entity._last_code == 0

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -592,7 +592,7 @@ async def test_check_health_creates_entity_registry_cleanup_issue(hass: HomeAssi
     coordinator.client = MagicMock()
     coordinator.data = {}
 
-    entry = SimpleNamespace(entry_id="entry-1")
+    entry = SimpleNamespace(entry_id="entry-1", data={}, options={})
     orphan = SimpleNamespace(entity_id="sensor.orphan", device_id="missing", unique_id="u1")
     dup1 = SimpleNamespace(entity_id="sensor.dup_1", device_id=None, unique_id="dup")
     dup2 = SimpleNamespace(entity_id="sensor.dup_2", device_id=None, unique_id="dup")
@@ -626,7 +626,7 @@ async def test_check_health_deletes_entity_registry_cleanup_issue_when_clean(
 
     async_create_issue(hass, "entity_registry_cleanup", "entity_registry_cleanup")
 
-    entry = SimpleNamespace(entry_id="entry-1")
+    entry = SimpleNamespace(entry_id="entry-1", data={}, options={})
     clean_entity = SimpleNamespace(entity_id="sensor.clean", device_id=None, unique_id="u1")
 
     with (

--- a/uv.lock
+++ b/uv.lock
@@ -35,14 +35,14 @@ wheels = [
 
 [[package]]
 name = "aiodns"
-version = "4.0.0"
+version = "4.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pycares" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/10/da/97235e953109936bfeda62c1f9f1a7c5652d4dc49f2b5911f9ae1043afa9/aiodns-4.0.0.tar.gz", hash = "sha256:17be26a936ba788c849ba5fd20e0ba69d8c46e6273e846eb5430eae2630ce5b1", size = 26204, upload-time = "2026-01-10T22:33:27.211Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/22/a2d928e0e42baad0471d12ec44c71152ac870486e8298dddb2893b888c29/aiodns-4.0.4.tar.gz", hash = "sha256:cb10e0c0d2591636716ad2fe402e977c16d71bdaf76bb8cb49e8a6633596f736", size = 29918, upload-time = "2026-05-20T01:54:15.557Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/60/14ac40c03e8a26216e4f2642497b776e52f9e3214e4fd537628829bbb082/aiodns-4.0.0-py3-none-any.whl", hash = "sha256:a188a75fb8b2b7862ac8f84811a231402fb74f5b4e6f10766dc8a4544b0cf989", size = 11334, upload-time = "2026-01-10T22:33:25.65Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/70/72e4ab117425ccdc4d10bd523a94c1baa051a15586057d64a4c6888f9e3f/aiodns-4.0.4-py3-none-any.whl", hash = "sha256:c24dd605bac70a1676ce503f967a98483ff163507198557d8e9db16267e6cfd2", size = 12696, upload-time = "2026-05-20T01:54:14.134Z" },
 ]
 
 [[package]]
@@ -260,15 +260,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ad/c3/76dfe55a68c48a1a6f3d2eeab2793ebffa9db8adfba82774a7e0f5f43980/astral-2.2.tar.gz", hash = "sha256:e41d9967d5c48be421346552f0f4dedad43ff39a83574f5ff2ad32b6627b6fbe", size = 578223, upload-time = "2020-05-20T14:23:17.602Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/91/60/7cc241b9c3710ebadddcb323e77dd422c693183aec92449a1cf1fb59e1ba/astral-2.2-py2.py3-none-any.whl", hash = "sha256:b9ef70faf32e81a8ba174d21e8f29dc0b53b409ef035f27e0749ddc13cb5982a", size = 30775, upload-time = "2020-05-20T14:23:14.866Z" },
-]
-
-[[package]]
-name = "astroid"
-version = "4.0.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/07/63/0adf26577da5eff6eb7a177876c1cfa213856be9926a000f65c4add9692b/astroid-4.0.4.tar.gz", hash = "sha256:986fed8bcf79fb82c78b18a53352a0b287a73817d6dbcfba3162da36667c49a0", size = 406358, upload-time = "2026-02-07T23:35:07.509Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/cf/1c5f42b110e57bc5502eb80dbc3b03d256926062519224835ef08134f1f9/astroid-4.0.4-py3-none-any.whl", hash = "sha256:52f39653876c7dec3e3afd4c2696920e05c83832b9737afc21928f2d2eb7a753", size = 276445, upload-time = "2026-02-07T23:35:05.344Z" },
 ]
 
 [[package]]
@@ -791,15 +782,6 @@ wheels = [
 ]
 
 [[package]]
-name = "dill"
-version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
-]
-
-[[package]]
 name = "envs"
 version = "1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -968,19 +950,25 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "homeassistant" },
+    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-homeassistant-custom-component" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "homeassistant", marker = "extra == 'dev'", specifier = ">=2026.5.4" },
     { name = "philips-airctrl", specifier = "==1.0.0" },
+    { name = "pyright", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-asyncio", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
     { name = "pytest-homeassistant-custom-component", marker = "extra == 'dev'" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.1" },
 ]
 provides-extras = ["dev"]
 
@@ -1062,7 +1050,7 @@ wheels = [
 
 [[package]]
 name = "homeassistant"
-version = "2026.5.1"
+version = "2026.5.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiodns" },
@@ -1116,9 +1104,9 @@ dependencies = [
     { name = "yarl" },
     { name = "zeroconf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/79/4b3737a59109c7a9a62fd935090be59d994d541f83a6e7dc0716f5bd6bb6/homeassistant-2026.5.1.tar.gz", hash = "sha256:1e9ee360b1cc41ba989ae4151ffed73e657ab6005d842657a4d866721c470948", size = 33119287, upload-time = "2026-05-08T20:22:11.984Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/ef/00fe5ef1f40daec592f8a28931eb6defa849d6cc3564a00f1d11b6f9d1ba/homeassistant-2026.5.4.tar.gz", hash = "sha256:a394baae7393ab33cb669301c609a9f48a662e51072ef1d31faf2a97612455b2", size = 33170704, upload-time = "2026-05-22T17:53:31.337Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/07/0f8b57e7ff671e7bfb3eba347e1be383b0894c98f2f23c59b12d035170f3/homeassistant-2026.5.1-py3-none-any.whl", hash = "sha256:0da76c5c3e4a28f7dc24abf45bd2b7c6dcc303ea5f94f1f57b71fdeb0bf8cc55", size = 54603868, upload-time = "2026-05-08T20:22:04.731Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/a2/6956f1f9603bbd0af581a4afe227e86fb819fbfcf21ee0cee64e129f0659/homeassistant-2026.5.4-py3-none-any.whl", hash = "sha256:3ba68dec2e9b9f67b3b0c67654cd5d138f14d31924b9701b840beccd00f8e85a", size = 54712939, upload-time = "2026-05-22T17:53:24.137Z" },
 ]
 
 [[package]]
@@ -1183,15 +1171,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
-]
-
-[[package]]
-name = "isort"
-version = "8.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592, upload-time = "2026-02-28T10:08:20.685Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733, upload-time = "2026-02-28T10:08:19.466Z" },
 ]
 
 [[package]]
@@ -1315,15 +1294,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mccabe"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
-]
-
-[[package]]
 name = "mock-open"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1379,6 +1349,15 @@ name = "netifaces"
 version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a6/91/86a6eac449ddfae239e93ffc1918cf33fd9bab35c04d1e963b311e347a73/netifaces-0.11.0.tar.gz", hash = "sha256:043a79146eb2907edf439899f262b3dfe41717d34124298ed281139a8b93ca32", size = 30106, upload-time = "2021-05-31T08:33:02.506Z" }
+
+[[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
 
 [[package]]
 name = "numpy"
@@ -1522,15 +1501,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/74/ef/9158ee3b28274667986d39191760c988a2de22c6321be1262e21c8a19ccf/pipdeptree-2.26.1.tar.gz", hash = "sha256:92a8f37ab79235dacb46af107e691a1309ca4a429315ba2a1df97d1cd56e27ac", size = 41024, upload-time = "2025-04-20T03:27:42.489Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b9/a5/f9f143b420e53a296869636d1c3bdc144be498ca3136a113f52b53ea2b02/pipdeptree-2.26.1-py3-none-any.whl", hash = "sha256:3849d62a2ed641256afac3058c4f9b85ac4a47e9d8c991ee17a8f3d230c5cffb", size = 32802, upload-time = "2025-04-20T03:27:40.413Z" },
-]
-
-[[package]]
-name = "platformdirs"
-version = "4.9.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
 ]
 
 [[package]]
@@ -1768,36 +1738,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pylint"
-version = "4.0.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "astroid" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "dill" },
-    { name = "isort" },
-    { name = "mccabe" },
-    { name = "platformdirs" },
-    { name = "tomlkit" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/b6/74d9a8a68b8067efce8d07707fe6a236324ee1e7808d2eb3646ec8517c7d/pylint-4.0.5.tar.gz", hash = "sha256:8cd6a618df75deb013bd7eb98327a95f02a6fb839205a6bbf5456ef96afb317c", size = 1572474, upload-time = "2026-02-20T09:07:33.621Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/6f/9ac2548e290764781f9e7e2aaf0685b086379dabfb29ca38536985471eaf/pylint-4.0.5-py3-none-any.whl", hash = "sha256:00f51c9b14a3b3ae08cff6b2cdd43f28165c78b165b628692e428fb1f8dc2cf2", size = 536694, upload-time = "2026-02-20T09:07:31.028Z" },
-]
-
-[[package]]
-name = "pylint-per-file-ignores"
-version = "3.2.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pylint" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/bc/6d40a3596f91ef23fca7b89983b78bf4b3686323fd98e44e53ae365b1880/pylint_per_file_ignores-3.2.1.tar.gz", hash = "sha256:0a89f3cdc6fa09244a3f5624ad977ac9b026f0b25b2adb48c97c080da8d858f9", size = 81844, upload-time = "2026-04-03T19:35:37.697Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/68/2b0cc27b549fd788caae254752910fe7222ac47c71627c60926895fe8960/pylint_per_file_ignores-3.2.1-py3-none-any.whl", hash = "sha256:aaac8b118791e742ccf7baaf42346978f6cd0440a9090d4087fc8ff26e4a31f2", size = 5699, upload-time = "2026-04-03T19:35:36.524Z" },
-]
-
-[[package]]
 name = "pynacl"
 version = "1.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1911,6 +1851,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/08/64/a99f27d3b4347486c7bfc0aa516016c46dc4c0f380ffccbd742a61af1eda/PyRIC-0.1.6.3.tar.gz", hash = "sha256:b539b01cafebd2406c00097f94525ea0f8ecd1dd92f7731f43eac0ef16c2ccc9", size = 870401, upload-time = "2016-12-04T07:54:48.374Z" }
 
 [[package]]
+name = "pyright"
+version = "1.1.409"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/4e/3aa27f74211522dba7e9cbc3e74de779c6d4b654c54e50a4840623be8014/pyright-1.1.409.tar.gz", hash = "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93", size = 4430434, upload-time = "2026-04-23T11:02:03.799Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/6b/330d8ebae582b30c2959a1ef4c3bc344ebde48c2ff0c3f113c4710735e11/pyright-1.1.409-py3-none-any.whl", hash = "sha256:aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3", size = 6438161, upload-time = "2026-04-23T11:02:01.309Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1993,7 +1946,7 @@ wheels = [
 
 [[package]]
 name = "pytest-homeassistant-custom-component"
-version = "0.13.330"
+version = "0.13.333"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohasupervisor" },
@@ -2006,7 +1959,6 @@ dependencies = [
     { name = "paho-mqtt" },
     { name = "pipdeptree" },
     { name = "pydantic" },
-    { name = "pylint-per-file-ignores" },
     { name = "pytest" },
     { name = "pytest-aiohttp" },
     { name = "pytest-asyncio" },
@@ -2024,9 +1976,9 @@ dependencies = [
     { name = "syrupy" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/00/ca/38e5f0e2fd886c128441d02212550da6685d85956682bd6a2729b226f4bf/pytest_homeassistant_custom_component-0.13.330.tar.gz", hash = "sha256:2b1509e41ab6ef5e2362ec15cc7a7d854478cb30a9faa79a8f4edf9f389e1af1", size = 77827, upload-time = "2026-05-09T05:57:55.708Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bd/33710be5657204c4128c47e0e6da2b4b5bf43e685ad83ec2bed056d1076f/pytest_homeassistant_custom_component-0.13.333.tar.gz", hash = "sha256:e8326bc96cdf0d8147a15ba99c10199e01fff98db96065258f6ac6921da411b6", size = 77794, upload-time = "2026-05-23T06:04:38.997Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/8e/b5646222b7c86c50a0e442763c1d21d9adc4f8a3b37fb3dd27b7c742a62c/pytest_homeassistant_custom_component-0.13.330-py3-none-any.whl", hash = "sha256:90880bb6ba923d5bd3598dad5654018dbc333f73889bdd505aac001d688d4f32", size = 83743, upload-time = "2026-05-09T05:57:54.129Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/51/1d15cceb7bd00ac50bdef5d40de4b17c2d5773f79bb16a73a4e4f58b2f7a/pytest_homeassistant_custom_component-0.13.333-py3-none-any.whl", hash = "sha256:53b6f110a1ea0c8fac52d131bbc1d4cb8d623afec602a62febd58e6939eb5eb8", size = 83728, upload-time = "2026-05-23T06:04:36.909Z" },
 ]
 
 [[package]]
@@ -2229,6 +2181,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.15.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/dc/4e6ac71b511b141cf626357a3946679abeba4cf67bc7cc5a17920f31e10d/ruff-0.15.1.tar.gz", hash = "sha256:c590fe13fb57c97141ae975c03a1aedb3d3156030cabd740d6ff0b0d601e203f", size = 4540855, upload-time = "2026-02-12T23:09:09.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/bf/e6e4324238c17f9d9120a9d60aa99a7daaa21204c07fcd84e2ef03bb5fd1/ruff-0.15.1-py3-none-linux_armv6l.whl", hash = "sha256:b101ed7cf4615bda6ffe65bdb59f964e9f4a0d3f85cbf0e54f0ab76d7b90228a", size = 10367819, upload-time = "2026-02-12T23:09:03.598Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/ea/c8f89d32e7912269d38c58f3649e453ac32c528f93bb7f4219258be2e7ed/ruff-0.15.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:939c995e9277e63ea632cc8d3fae17aa758526f49a9a850d2e7e758bfef46602", size = 10798618, upload-time = "2026-02-12T23:09:22.928Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/0f/1d0d88bc862624247d82c20c10d4c0f6bb2f346559d8af281674cf327f15/ruff-0.15.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1d83466455fdefe60b8d9c8df81d3c1bbb2115cede53549d3b522ce2bc703899", size = 10148518, upload-time = "2026-02-12T23:08:58.339Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/c8/291c49cefaa4a9248e986256df2ade7add79388fe179e0691be06fae6f37/ruff-0.15.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a9457e3c3291024866222b96108ab2d8265b477e5b1534c7ddb1810904858d16", size = 10518811, upload-time = "2026-02-12T23:09:31.865Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/1a/f5707440e5ae43ffa5365cac8bbb91e9665f4a883f560893829cf16a606b/ruff-0.15.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:92c92b003e9d4f7fbd33b1867bb15a1b785b1735069108dfc23821ba045b29bc", size = 10196169, upload-time = "2026-02-12T23:09:17.306Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/ff/26ddc8c4da04c8fd3ee65a89c9fb99eaa5c30394269d424461467be2271f/ruff-0.15.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1fe5c41ab43e3a06778844c586251eb5a510f67125427625f9eb2b9526535779", size = 10990491, upload-time = "2026-02-12T23:09:25.503Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/00/50920cb385b89413f7cdb4bb9bc8fc59c1b0f30028d8bccc294189a54955/ruff-0.15.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:66a6dd6df4d80dc382c6484f8ce1bcceb55c32e9f27a8b94c32f6c7331bf14fb", size = 11843280, upload-time = "2026-02-12T23:09:19.88Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/6d/2f5cad8380caf5632a15460c323ae326f1e1a2b5b90a6ee7519017a017ca/ruff-0.15.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6a4a42cbb8af0bda9bcd7606b064d7c0bc311a88d141d02f78920be6acb5aa83", size = 11274336, upload-time = "2026-02-12T23:09:14.907Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/1d/5f56cae1d6c40b8a318513599b35ea4b075d7dc1cd1d04449578c29d1d75/ruff-0.15.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4ab064052c31dddada35079901592dfba2e05f5b1e43af3954aafcbc1096a5b2", size = 11137288, upload-time = "2026-02-12T23:09:07.475Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/20/6f8d7d8f768c93b0382b33b9306b3b999918816da46537d5a61635514635/ruff-0.15.1-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:5631c940fe9fe91f817a4c2ea4e81f47bee3ca4aa646134a24374f3c19ad9454", size = 11070681, upload-time = "2026-02-12T23:08:55.43Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/67/d640ac76069f64cdea59dba02af2e00b1fa30e2103c7f8d049c0cff4cafd/ruff-0.15.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:68138a4ba184b4691ccdc39f7795c66b3c68160c586519e7e8444cf5a53e1b4c", size = 10486401, upload-time = "2026-02-12T23:09:27.927Z" },
+    { url = "https://files.pythonhosted.org/packages/65/3d/e1429f64a3ff89297497916b88c32a5cc88eeca7e9c787072d0e7f1d3e1e/ruff-0.15.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:518f9af03bfc33c03bdb4cb63fabc935341bb7f54af500f92ac309ecfbba6330", size = 10197452, upload-time = "2026-02-12T23:09:12.147Z" },
+    { url = "https://files.pythonhosted.org/packages/78/83/e2c3bade17dad63bf1e1c2ffaf11490603b760be149e1419b07049b36ef2/ruff-0.15.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:da79f4d6a826caaea95de0237a67e33b81e6ec2e25fc7e1993a4015dffca7c61", size = 10693900, upload-time = "2026-02-12T23:09:34.418Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/27/fdc0e11a813e6338e0706e8b39bb7a1d61ea5b36873b351acee7e524a72a/ruff-0.15.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:3dd86dccb83cd7d4dcfac303ffc277e6048600dfc22e38158afa208e8bf94a1f", size = 11227302, upload-time = "2026-02-12T23:09:36.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/58/ac864a75067dcbd3b95be5ab4eb2b601d7fbc3d3d736a27e391a4f92a5c1/ruff-0.15.1-py3-none-win32.whl", hash = "sha256:660975d9cb49b5d5278b12b03bb9951d554543a90b74ed5d366b20e2c57c2098", size = 10462555, upload-time = "2026-02-12T23:09:29.899Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/5e/d4ccc8a27ecdb78116feac4935dfc39d1304536f4296168f91ed3ec00cd2/ruff-0.15.1-py3-none-win_amd64.whl", hash = "sha256:c820fef9dd5d4172a6570e5721704a96c6679b80cf7be41659ed439653f62336", size = 11599956, upload-time = "2026-02-12T23:09:01.157Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/07/5bda6a85b220c64c65686bc85bd0bbb23b29c62b3a9f9433fa55f17cda93/ruff-0.15.1-py3-none-win_arm64.whl", hash = "sha256:5ff7d5f0f88567850f45081fac8f4ec212be8d0b963e385c3f7d0d2eb4899416", size = 10874604, upload-time = "2026-02-12T23:09:05.515Z" },
+]
+
+[[package]]
 name = "s3transfer"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2372,15 +2349,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
-]
-
-[[package]]
-name = "tomlkit"
-version = "0.15.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/51/db/03eaf4331631ef6b27d6e3c9b68c54dc6f0d63d87201fed600cc409307fd/tomlkit-0.15.0.tar.gz", hash = "sha256:7d1a9ecba3086638211b13814ea79c90dd54dd11993564376f3aa92271f5c7a3", size = 161875, upload-time = "2026-05-10T07:38:22.245Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/43/8bd850ee71a191bf072e31302c73a66be413fecdd98fdcd111ecbcce13ca/tomlkit-0.15.0-py3-none-any.whl", hash = "sha256:4dbc8f0fc024412b57ced8757ac7461305126a648ff8c2c807fcb8e133a78738", size = 41328, upload-time = "2026-05-10T07:38:23.517Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -962,7 +962,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", marker = "extra == 'dev'", specifier = ">=2026.5.4" },
-    { name = "philips-airctrl", specifier = "==1.0.0" },
+    { name = "philips-airctrl", specifier = "==1.1.0" },
     { name = "pyright", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-asyncio", marker = "extra == 'dev'" },
@@ -1432,7 +1432,7 @@ wheels = [
 
 [[package]]
 name = "philips-airctrl"
-version = "1.0.0"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiocoap" },
@@ -1443,9 +1443,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "tabulate" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/57/2273249ae364f20b41343edd5cc4e8178e47227fb893790d55de7de8efc6/philips_airctrl-1.0.0.tar.gz", hash = "sha256:323820267689b78107e831394634a332590c36a8a9c590c145a0862169825ee8", size = 85330, upload-time = "2026-02-13T06:21:15.285Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/56/59f46b3c6c2b76df66943256bc2a18e4d100b2912eaf15ac7a03c59a35b4/philips_airctrl-1.1.0.tar.gz", hash = "sha256:16d7fe45139b1bf3b86da9fcc62b55c2e6795fbd15d8cb887ab72221c69cc3ee", size = 86898, upload-time = "2026-05-29T00:19:42.218Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/b1/512b3fabc716f6bc379bf2d4fb6a47b5232aa9c6da37b48b49e78301b597/philips_airctrl-1.0.0-py3-none-any.whl", hash = "sha256:92b4092374fd9df0033686b259739bb772322ca20c7218322507d805805000c0", size = 23387, upload-time = "2026-02-13T06:21:13.637Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ed/444baa9dd28a5e3f53b21b10c7e9098f38f8485e6a9ffb097e19da07ba67/philips_airctrl-1.1.0-py3-none-any.whl", hash = "sha256:7906001b35999dfccd41f7e140c53f23201f124536ca037fe1b1349a7afc3642", size = 23900, upload-time = "2026-05-29T00:19:40.836Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bundles the dev-container/HA upgrade, three issue fixes, a new notification event entity, and the philips-airctrl 1.1.0 observe-free status work.

### Dev container & tooling
- Pin to the latest stable **Home Assistant 2026.5.4** (`homeassistant>=2026.5.4` floor so `uv lock` can't resolve backwards); leave `pytest-homeassistant-custom-component` unpinned to match the stable HA.
- Dependabot: switch Python ecosystem `pip` → **`uv`** (daily), add **`docker`** (dev-container base image) and **`devcontainers`** ecosystems.
- Add `ruff==0.15.1` + `pyright` to dev deps — `scripts/lint`/`check`/`type-check` and the lint CI job call `uv run ruff`/`uv run pyright` but neither was installed, so they (and CI) were broken.
- Fix `scripts/develop` to use `uv run hass` in the config-bootstrap path.

### Issue fixes
- **#29** — TVOC sensor: drop the incorrect `volatile_organic_compounds` device class (the value is a level/index, not µg/m³) and give it a plain icon, fixing the repeated validation warning. Filter-replacement repair now persists acknowledgment (config-entry option), deletes the issue on fix, and auto-resets when filters read healthy — so it stops reappearing on every update.
- **#26** — add the **AC2221/13** Gen3 model config (PM2.5 + allergen, lamp/ambient/preferred-index; no humidifier, no gas).
- **#8** — capture the device MAC at DHCP discovery, register it as a device `connection`, and include it in host updates, so `registered_devices` DHCP re-discovery updates the IP after a lease change.

### New: notification event entity
- `event.py` adds an `EventEntity` that surfaces device notifications (`error` / `out_of_water` / `cleared`) with code details, reading only `coordinator.data`. Created only when the device reports an error-code key.

### philips-airctrl 1.1.0 (observe-free reads)
- Bump requirement to **1.1.0** and use `get_status(observe=False)` for all one-shot reads (discovery, repairs, and the coordinator's initial/reconnect/fallback reads) so they no longer leave a CoAP observation registered. Ongoing updates still use the `observe_status()` push stream. (ruaan-deysel/philips-airctrl#6)

### Version
- Bump integration to `2026.5.0`.

## Validation
- 325 tests pass; ruff format/check clean; pyright 0 errors.
- Verified end-to-end at runtime on HA 2026.5.4 against a real **AC4220/12**: integration loads, one-shot `observe=False` initial read succeeds, observe push stream delivers updates, and the `event.bedroom_notification` entity is created.

> Note: PR #31 (the polling-recovery PR) is superseded by the upstream library fix and can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Philips AC2221 air purifier model.
  * Added event notifications for device errors and filter alerts.
  * Implemented device rediscovery using MAC address after network IP changes.
  * Added persistent acknowledgement tracking for filter replacement warnings.

* **Improvements**
  * Enhanced CoAP protocol handling for reliable status updates.

* **Chores**
  * Updated philips-airctrl dependency to version 1.1.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ruaan-deysel/ha-philips-airpurifier/pull/32?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->