### PR TITLE
fix(amf870): restore rotation (oscillation) control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,11 @@ and this project adheres to [Calendar Versioning](https://calver.org/) (`YYYY.MM
   exposed the on/off control.
 - On the **AMF765** and **AMF870**, where the angle and the on/off state share
   one device key, switching oscillation back on now restores the rotation angle
-  the device last reported instead of overwriting it with a fixed value. Models
-  whose oscillation key is a fixed on/off code are unaffected and keep writing
-  their documented on-value.
+  the device last reported instead of overwriting it with a fixed value. When no
+  angle has been reported yet — for example right after a Home Assistant restart
+  — it starts at the configured default of 90° instead. Models whose oscillation
+  key is a fixed on/off code are unaffected and keep writing their documented
+  on-value.
 - The `oscillation` and `target_temperature` number entities are translated
   again in German, Dutch and Bulgarian. Their translation keys were misspelled
   (`oscillaton`, `target_temp`) and never matched `strings.json`, so those

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Calendar Versioning](https://calver.org/) (`YYYY.MM
 
 ## [Unreleased]
 
+### Fixed
+
+- Rotation (oscillation) control is available again on the **AMF870**
+  (Series 8000i 2-in-1). The model configuration listed only the target
+  temperature under its numbers, which replaced rather than extended the AMF
+  family defaults and silently dropped the rotation angle entity. The
+  **Oscillation** number (0° = off, 30°–350° in 5° steps) is restored next to
+  the target temperature, and the fan entity now supports the standard
+  `fan.oscillate` service and the oscillation toggle in the UI. The AMF765
+  gains the same oscillation toggle — it kept the angle entity but never
+  exposed the on/off control.
+- Switching oscillation back on now restores the rotation angle the device last
+  reported instead of overwriting it with a fixed value. This matters on the
+  AMF family, where the angle and the on/off state share one device key.
+- The `oscillation` and `target_temperature` number entities are translated
+  again in German, Dutch and Bulgarian. Their translation keys were misspelled
+  (`oscillaton`, `target_temp`) and never matched `strings.json`, so those
+  entities fell back to their English names.
+
 ### Added
 
 - Support for the **CX7550/01** (Philips oscillating tower fan). It uses Gen3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,11 @@ and this project adheres to [Calendar Versioning](https://calver.org/) (`YYYY.MM
   `fan.oscillate` service and the oscillation toggle in the UI. The AMF765
   gains the same oscillation toggle — it kept the angle entity but never
   exposed the on/off control.
-- On the AMF family, where the angle and the on/off state share one device key,
-  switching oscillation back on now restores the rotation angle the device last
-  reported instead of overwriting it with a fixed value. Models whose
-  oscillation key is a fixed on/off code are unaffected and keep writing their
-  documented on-value.
+- On the **AMF765** and **AMF870**, where the angle and the on/off state share
+  one device key, switching oscillation back on now restores the rotation angle
+  the device last reported instead of overwriting it with a fixed value. Models
+  whose oscillation key is a fixed on/off code are unaffected and keep writing
+  their documented on-value.
 - The `oscillation` and `target_temperature` number entities are translated
   again in German, Dutch and Bulgarian. Their translation keys were misspelled
   (`oscillaton`, `target_temp`) and never matched `strings.json`, so those

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,11 @@ and this project adheres to [Calendar Versioning](https://calver.org/) (`YYYY.MM
   `fan.oscillate` service and the oscillation toggle in the UI. The AMF765
   gains the same oscillation toggle — it kept the angle entity but never
   exposed the on/off control.
-- Switching oscillation back on now restores the rotation angle the device last
-  reported instead of overwriting it with a fixed value. This matters on the
-  AMF family, where the angle and the on/off state share one device key.
+- On the AMF family, where the angle and the on/off state share one device key,
+  switching oscillation back on now restores the rotation angle the device last
+  reported instead of overwriting it with a fixed value. Models whose
+  oscillation key is a fixed on/off code are unaffected and keep writing their
+  documented on-value.
 - The `oscillation` and `target_temperature` number entities are translated
   again in German, Dutch and Bulgarian. Their translation keys were misspelled
   (`oscillaton`, `target_temp`) and never matched `strings.json`, so those

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ If your device changes IP addresses:
 | **Air Purifiers** | 50+ models     | AC0650, AC0850, AC0950, AC1214, AC1715, AC2729, AC2889, AC2936, AC3033, AC3055, AC3210, AC3259, AC3420, AC3737, AC3829, AC3854, AC3858, AC4220, AC4550, AC5659 |
 | **2-in-1 Combos** | 7 models       | AC0850C series, AMF765, AMF870                                                                                                                                 |
 | **Humidifiers**   | 5 models       | CX3120, CX3550, CX5120, HU1509, HU1510, HU5710                                                                                                                 |
-| **Fans**          | 1 model        | CX7550                                                                                                                                                          |
+| **Fans**          | 1 model        | CX7550                                                                                                                                                         |
 | **Total**         | **63+ models** | **29 series**                                                                                                                                                  |
 
 ### Air Purifiers
@@ -204,6 +204,13 @@ If your device changes IP addresses:
 - AMF series are dedicated 2-in-1 air purifier and humidifier devices
 - CX and HU series are dedicated humidifiers
 
+**AMF765 / AMF870 Rotation (Oscillation) Notes:**
+
+- The AMF models keep the rotation angle and the on/off state in a single device value, which this integration surfaces in two ways:
+  - the **Oscillation** number entity sets the angle directly — `0°` stops the rotation, `30°` to `350°` (in 5° steps) start it at that angle;
+  - the fan entity's **oscillation** toggle (`fan.oscillate`) starts and stops the rotation without having to pick an angle.
+- Turning the rotation off and on again restores the last angle the device reported. If no angle has been seen yet (for example right after a Home Assistant restart), switching it on uses 90°.
+
 **CX7550 Oscillating Fan Notes:**
 
 - **Initial setup requires the Philips Air app**: the CX7550 must first be joined to your Wi-Fi network with the official Philips Air mobile app. Once it is on the network, this integration controls it entirely locally over CoAP — no cloud or app is needed for day-to-day use.
@@ -218,7 +225,7 @@ This integration provides comprehensive control through various Home Assistant e
 
 | Entity Type    | Description                             | Features                              |
 | -------------- | --------------------------------------- | ------------------------------------- |
-| **Fan**        | Main device control                     | Power, speed control, preset modes    |
+| **Fan**        | Main device control                     | Power, speed, preset modes, rotation  |
 | **Humidifier** | Humidity control (2-in-1 models)        | Target humidity, humidification modes |
 | **Climate**    | Temperature control (applicable models) | Temperature settings, heating modes   |
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ If your device changes IP addresses:
 - The AMF models keep the rotation angle and the on/off state in a single device value, which this integration surfaces in two ways:
   - the **Oscillation** number entity sets the angle directly — `0°` stops the rotation, `30°` to `350°` (in 5° steps) start it at that angle;
   - the fan entity's **oscillation** toggle (`fan.oscillate`) starts and stops the rotation without having to pick an angle.
-- Turning the rotation off and on again restores the last angle the device reported. If no angle has been seen yet (for example right after a Home Assistant restart), switching it on uses 90°.
+- Turning the rotation off and on again restores the last angle the device reported. If no angle has been seen yet (for example, right after a Home Assistant restart), switching it on uses 90°.
 
 **CX7550 Oscillating Fan Notes:**
 

--- a/custom_components/philips_airpurifier/const.py
+++ b/custom_components/philips_airpurifier/const.py
@@ -389,7 +389,7 @@ class PhilipsApi:
     # D0320F: 0 is off, 30..350 is the oscillation angle in degrees. The "on"
     # value below is only the fallback used when no angle has been observed
     # yet -- the fan entity restores the last reported angle when available.
-    OSCILLATION_MAP5 = {
+    OSCILLATION_MAP5: dict[str, int] = {
         SWITCH_ON: 90,
         SWITCH_OFF: 0,
     }

--- a/custom_components/philips_airpurifier/const.py
+++ b/custom_components/philips_airpurifier/const.py
@@ -385,6 +385,14 @@ class PhilipsApi:
         SWITCH_ON: 80,
         SWITCH_OFF: 0,
     }
+    # The AMF family (AMF765, AMF870) stores the rotation angle itself in
+    # D0320F: 0 is off, 30..350 is the oscillation angle in degrees. The "on"
+    # value below is only the fallback used when no angle has been observed
+    # yet -- the fan entity restores the last reported angle when available.
+    OSCILLATION_MAP5 = {
+        SWITCH_ON: 90,
+        SWITCH_OFF: 0,
+    }
 
     # the AC1715 seems to follow a new scheme, this should later be refactored
     NEW_NAME = "D01-03"

--- a/custom_components/philips_airpurifier/device_models.py
+++ b/custom_components/philips_airpurifier/device_models.py
@@ -1340,6 +1340,7 @@ DEVICE_MODELS: dict[str, DeviceModelConfig] = {
         oscillation={
             PhilipsApi.NEW2_OSCILLATION: PhilipsApi.OSCILLATION_MAP5,
         },
+        oscillation_is_angle=True,
         unavailable_sensors=[PhilipsApi.NEW2_GAS],
     ),
     # =========================================================================
@@ -1371,6 +1372,7 @@ DEVICE_MODELS: dict[str, DeviceModelConfig] = {
         oscillation={
             PhilipsApi.NEW2_OSCILLATION: PhilipsApi.OSCILLATION_MAP5,
         },
+        oscillation_is_angle=True,
     ),
     # =========================================================================
     # CX3120

--- a/custom_components/philips_airpurifier/device_models.py
+++ b/custom_components/philips_airpurifier/device_models.py
@@ -1337,6 +1337,9 @@ DEVICE_MODELS: dict[str, DeviceModelConfig] = {
         # AMF765 overrides selects from AMFxxx
         selects=[PhilipsApi.NEW2_CIRCULATION],
         numbers=[PhilipsApi.NEW2_OSCILLATION],
+        oscillation={
+            PhilipsApi.NEW2_OSCILLATION: PhilipsApi.OSCILLATION_MAP5,
+        },
         unavailable_sensors=[PhilipsApi.NEW2_GAS],
     ),
     # =========================================================================
@@ -1358,8 +1361,16 @@ DEVICE_MODELS: dict[str, DeviceModelConfig] = {
             PhilipsApi.NEW2_GAS_PREFERRED_INDEX,
             PhilipsApi.NEW2_HEATING,
         ],
-        # AMF870 overrides numbers from AMFxxx
-        numbers=[PhilipsApi.NEW2_TARGET_TEMP],
+        # AMF870 adds the target temperature on top of the AMFxxx oscillation
+        # angle. Both numbers must be listed: dropping NEW2_OSCILLATION here
+        # removes the rotation angle control from the device entirely.
+        numbers=[
+            PhilipsApi.NEW2_OSCILLATION,
+            PhilipsApi.NEW2_TARGET_TEMP,
+        ],
+        oscillation={
+            PhilipsApi.NEW2_OSCILLATION: PhilipsApi.OSCILLATION_MAP5,
+        },
     ),
     # =========================================================================
     # CX3120

--- a/custom_components/philips_airpurifier/fan.py
+++ b/custom_components/philips_airpurifier/fan.py
@@ -72,7 +72,7 @@ class PhilipsFan(PhilipsAirPurifierEntity, FanEntity):  # pragma: no cover
         # the fixed-code models are not assumed to report the value that has
         # to be written to switch oscillation on, so writing a reported value
         # back could set something other than "on".
-        self._oscillation_is_angle = model_config.oscillation_is_angle
+        self._oscillation_is_angle: bool = model_config.oscillation_is_angle
         self._last_oscillation_value: Any | None = None
 
         # Set supported features

--- a/custom_components/philips_airpurifier/fan.py
+++ b/custom_components/philips_airpurifier/fan.py
@@ -208,6 +208,7 @@ class PhilipsFan(PhilipsAirPurifierEntity, FanEntity):  # pragma: no cover
             if current is not None and current != off:
                 self._last_oscillation_value = current
 
+        value: Any
         if not oscillating:
             value = off
         elif self._last_oscillation_value is not None:

--- a/custom_components/philips_airpurifier/fan.py
+++ b/custom_components/philips_airpurifier/fan.py
@@ -194,8 +194,17 @@ class PhilipsFan(PhilipsAirPurifierEntity, FanEntity):  # pragma: no cover
         if self._oscillation_key is None or self._oscillation_values is None:
             return
 
+        off = self._oscillation_values[SWITCH_OFF]
+        current = self._device_status.get(self._oscillation_key)
+
+        if current is not None and current != off:
+            # Capture the angle the device is rotating at right now: the write
+            # below overwrites it, and Home Assistant may not have read the
+            # oscillating property since the device last reported a new angle.
+            self._last_oscillation_value = current
+
         if not oscillating:
-            value = self._oscillation_values[SWITCH_OFF]
+            value = off
         elif self._last_oscillation_value is not None:
             value = self._last_oscillation_value
         else:

--- a/custom_components/philips_airpurifier/fan.py
+++ b/custom_components/philips_airpurifier/fan.py
@@ -198,13 +198,13 @@ class PhilipsFan(PhilipsAirPurifierEntity, FanEntity):  # pragma: no cover
         if self._oscillation_key is None or self._oscillation_values is None:
             return
 
-        off = self._oscillation_values[SWITCH_OFF]
+        off: Any = self._oscillation_values[SWITCH_OFF]
 
         if self._oscillation_is_angle:
             # Capture the angle the device is rotating at right now: the write
             # below overwrites it, and Home Assistant may not have read the
             # oscillating property since the device last reported a new angle.
-            current = self._device_status.get(self._oscillation_key)
+            current: Any | None = self._device_status.get(self._oscillation_key)
             if current is not None and current != off:
                 self._last_oscillation_value = current
 

--- a/custom_components/philips_airpurifier/fan.py
+++ b/custom_components/philips_airpurifier/fan.py
@@ -64,6 +64,12 @@ class PhilipsFan(PhilipsAirPurifierEntity, FanEntity):  # pragma: no cover
         self._speeds_map = model_config.speeds
         self._speeds_list = list(self._speeds_map.keys())
         self._oscillation = model_config.oscillation
+        self._oscillation_key: str | None = None
+        self._oscillation_values: dict[str, Any] | None = None
+        # Last non-off value the device reported for the oscillation key. On
+        # models where that key holds the rotation angle (AMF765, AMF870) this
+        # is the angle to restore when oscillation is switched back on.
+        self._last_oscillation_value: Any | None = None
 
         # Set supported features
         self._attr_supported_features = (
@@ -75,6 +81,8 @@ class PhilipsFan(PhilipsAirPurifierEntity, FanEntity):  # pragma: no cover
 
         if self._oscillation is not None:
             self._attr_supported_features |= FanEntityFeature.OSCILLATE
+            self._oscillation_key = next(iter(self._oscillation))
+            self._oscillation_values = self._oscillation[self._oscillation_key]
 
     @property
     def is_on(self) -> bool:
@@ -162,28 +170,37 @@ class PhilipsFan(PhilipsAirPurifierEntity, FanEntity):  # pragma: no cover
     @property
     def oscillating(self) -> bool | None:  # pragma: no cover
         """Return if the fan is oscillating."""
-        if self._oscillation is None:  # pragma: no cover
+        if self._oscillation_key is None or self._oscillation_values is None:  # pragma: no cover
             return None
 
-        key = next(iter(self._oscillation))
-        values = self._oscillation[key]
-        off = values[SWITCH_OFF]
-        status = self._device_status.get(key)
+        status = self._device_status.get(self._oscillation_key)
 
         if status is None:  # pragma: no cover
             return None
 
-        return status != off
+        oscillating = status != self._oscillation_values[SWITCH_OFF]
+
+        if oscillating:
+            # Home Assistant reads this property on every state write, so it is
+            # the one place that sees every status the device reports. Remember
+            # the value so async_oscillate can restore it rather than force the
+            # generic "on" value over a user-picked rotation angle.
+            self._last_oscillation_value = status
+
+        return oscillating
 
     async def async_oscillate(self, oscillating: bool) -> None:  # pragma: no cover
         """Set the oscillation of the fan."""
-        if self._oscillation is None:
+        if self._oscillation_key is None or self._oscillation_values is None:
             return
 
-        key = next(iter(self._oscillation))
-        values = self._oscillation[key]
-        value = values[SWITCH_ON] if oscillating else values[SWITCH_OFF]
+        if not oscillating:
+            value = self._oscillation_values[SWITCH_OFF]
+        elif self._last_oscillation_value is not None:
+            value = self._last_oscillation_value
+        else:
+            value = self._oscillation_values[SWITCH_ON]
 
-        await self.coordinator.async_set_control_value(key, value)
-        self._device_status[key] = value
+        await self.coordinator.async_set_control_value(self._oscillation_key, value)
+        self._device_status[self._oscillation_key] = value
         self._handle_coordinator_update()

--- a/custom_components/philips_airpurifier/fan.py
+++ b/custom_components/philips_airpurifier/fan.py
@@ -66,9 +66,13 @@ class PhilipsFan(PhilipsAirPurifierEntity, FanEntity):  # pragma: no cover
         self._oscillation = model_config.oscillation
         self._oscillation_key: str | None = None
         self._oscillation_values: dict[str, Any] | None = None
-        # Last non-off value the device reported for the oscillation key. On
-        # models where that key holds the rotation angle (AMF765, AMF870) this
-        # is the angle to restore when oscillation is switched back on.
+        # Last non-off value the device reported for the oscillation key, and
+        # the angle to restore when oscillation is switched back on. Only
+        # tracked for models whose oscillation key holds the rotation angle:
+        # the fixed-code models are not assumed to report the value that has
+        # to be written to switch oscillation on, so writing a reported value
+        # back could set something other than "on".
+        self._oscillation_is_angle = model_config.oscillation_is_angle
         self._last_oscillation_value: Any | None = None
 
         # Set supported features
@@ -180,10 +184,10 @@ class PhilipsFan(PhilipsAirPurifierEntity, FanEntity):  # pragma: no cover
 
         oscillating = status != self._oscillation_values[SWITCH_OFF]
 
-        if oscillating:
+        if oscillating and self._oscillation_is_angle:
             # Home Assistant reads this property on every state write, so it is
-            # the one place that sees every status the device reports. Remember
-            # the value so async_oscillate can restore it rather than force the
+            # the one place that sees every angle the device reports. Remember
+            # it so async_oscillate can restore it rather than force the
             # generic "on" value over a user-picked rotation angle.
             self._last_oscillation_value = status
 
@@ -195,13 +199,14 @@ class PhilipsFan(PhilipsAirPurifierEntity, FanEntity):  # pragma: no cover
             return
 
         off = self._oscillation_values[SWITCH_OFF]
-        current = self._device_status.get(self._oscillation_key)
 
-        if current is not None and current != off:
+        if self._oscillation_is_angle:
             # Capture the angle the device is rotating at right now: the write
             # below overwrites it, and Home Assistant may not have read the
             # oscillating property since the device last reported a new angle.
-            self._last_oscillation_value = current
+            current = self._device_status.get(self._oscillation_key)
+            if current is not None and current != off:
+                self._last_oscillation_value = current
 
         if not oscillating:
             value = off

--- a/custom_components/philips_airpurifier/model.py
+++ b/custom_components/philips_airpurifier/model.py
@@ -73,6 +73,12 @@ class DeviceModelConfig:
     unavailable_filters: list[str] = field(default_factory=_default_string_list)
     unavailable_sensors: list[str] = field(default_factory=_default_string_list)
     oscillation: dict[str, dict[str, Any]] | None = None
+    # True when the oscillation key holds the rotation angle itself rather than
+    # a fixed on/off code (the AMF family: 0 = off, 30..350 = degrees). Only
+    # then may a reported value be written back to restore the previous angle;
+    # for the fixed-code models the device is not assumed to report the value
+    # that has to be written to switch oscillation on.
+    oscillation_is_angle: bool = False
     create_fan: bool = True
     # Special behavior flags
     requires_mode_cycling: bool = False  # AC1214 needs mode cycling

--- a/custom_components/philips_airpurifier/translations/bg.json
+++ b/custom_components/philips_airpurifier/translations/bg.json
@@ -273,10 +273,10 @@
       }
     },
     "number": {
-      "oscillaton": {
+      "oscillation": {
         "name": "Осцилация"
       },
-      "target_temp": {
+      "target_temperature": {
         "name": "Целева температура"
       }
     }

--- a/custom_components/philips_airpurifier/translations/de.json
+++ b/custom_components/philips_airpurifier/translations/de.json
@@ -274,11 +274,11 @@
       }
     },
     "number": {
-      "oscillaton": {
+      "oscillation": {
         "name": "Oszillation"
       },
-      "target_temp": {
-        "name": "Ziel Temperature"
+      "target_temperature": {
+        "name": "Zieltemperatur"
       }
     }
   }

--- a/custom_components/philips_airpurifier/translations/nl.json
+++ b/custom_components/philips_airpurifier/translations/nl.json
@@ -240,10 +240,10 @@
       }
     },
     "number": {
-      "oscillaton": {
+      "oscillation": {
         "name": "Oscillatie"
       },
-      "target_temp": {
+      "target_temperature": {
         "name": "Doeltemperatuur"
       }
     }

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -490,6 +490,43 @@ async def test_fan_oscillate_restores_last_angle() -> None:
     coordinator.async_set_control_value.assert_awaited_with("D0320F", 350)
 
 
+async def test_fan_oscillate_captures_angle_without_state_read() -> None:
+    """Test switching off captures an angle the oscillating property never saw."""
+    entity, coordinator = _make_fan_entity(
+        "AMF870",
+        {"D03102": 1, "D0310C": 2, "D0320F": 60},
+    )
+    entity._handle_coordinator_update = lambda: None
+
+    # `oscillating` is deliberately not read here: the device reported 60 and
+    # Home Assistant has not written the fan state since.
+    await entity.async_oscillate(False)
+    coordinator.async_set_control_value.assert_awaited_with("D0320F", 0)
+
+    coordinator.async_set_control_value.reset_mock()
+    await entity.async_oscillate(True)
+    coordinator.async_set_control_value.assert_awaited_with("D0320F", 60)
+
+
+async def test_fan_oscillate_prefers_newest_reported_angle() -> None:
+    """Test a newer device angle supersedes the previously cached one."""
+    entity, coordinator = _make_fan_entity(
+        "AMF870",
+        {"D03102": 1, "D0310C": 2, "D0320F": 60},
+    )
+    entity._handle_coordinator_update = lambda: None
+
+    assert entity.oscillating is True  # caches 60
+
+    # The angle is changed on the device itself and pushed to the coordinator.
+    coordinator.data["D0320F"] = 180
+
+    await entity.async_oscillate(False)
+    coordinator.async_set_control_value.reset_mock()
+    await entity.async_oscillate(True)
+    coordinator.async_set_control_value.assert_awaited_with("D0320F", 180)
+
+
 async def test_fan_oscillate_falls_back_to_default_angle() -> None:
     """Test oscillating on uses the configured value when no angle is known."""
     entity, coordinator = _make_fan_entity(

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -462,3 +462,43 @@ async def test_fan_oscillate_noop_without_oscillation() -> None:
     entity, coordinator = _make_fan_entity("AC3858/51", {"pwr": "1", "mode": "AG", "om": "a"})
     await entity.async_oscillate(True)
     coordinator.async_set_control_value.assert_not_called()
+
+
+async def test_fan_amf870_supports_oscillate() -> None:
+    """Test the AMF870 fan exposes the oscillate feature."""
+    entity, _ = _make_fan_entity("AMF870", {"D03102": 1, "D0310C": 2, "D0320F": 0})
+    assert entity.supported_features & FanEntityFeature.OSCILLATE
+
+
+async def test_fan_oscillate_restores_last_angle() -> None:
+    """Test oscillating back on restores the angle the device last reported."""
+    entity, coordinator = _make_fan_entity(
+        "AMF870",
+        {"D03102": 1, "D0310C": 2, "D0320F": 350},
+    )
+    entity._handle_coordinator_update = lambda: None
+
+    # Reading the state records the rotation angle reported by the device.
+    assert entity.oscillating is True
+
+    await entity.async_oscillate(False)
+    coordinator.async_set_control_value.assert_awaited_with("D0320F", 0)
+    assert entity.oscillating is False
+
+    coordinator.async_set_control_value.reset_mock()
+    await entity.async_oscillate(True)
+    coordinator.async_set_control_value.assert_awaited_with("D0320F", 350)
+
+
+async def test_fan_oscillate_falls_back_to_default_angle() -> None:
+    """Test oscillating on uses the configured value when no angle is known."""
+    entity, coordinator = _make_fan_entity(
+        "AMF870",
+        {"D03102": 1, "D0310C": 2, "D0320F": 0},
+    )
+    entity._handle_coordinator_update = lambda: None
+
+    assert entity.oscillating is False
+
+    await entity.async_oscillate(True)
+    coordinator.async_set_control_value.assert_awaited_with("D0320F", 90)

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -464,6 +464,27 @@ async def test_fan_oscillate_noop_without_oscillation() -> None:
     coordinator.async_set_control_value.assert_not_called()
 
 
+async def test_fan_oscillate_keeps_fixed_on_value_for_legacy_maps() -> None:
+    """Test fixed-code models always write their documented on-value."""
+    # CX3120 uses OSCILLATION_MAP3 (on -> 45). The device reports 60 here: a
+    # value that must never be written back as if it switched oscillation on.
+    entity, coordinator = _make_fan_entity(
+        "CX3120",
+        {"D03102": 1, "D0310A": 3, "D0310C": 0, "D0320F": 60},
+    )
+    entity._handle_coordinator_update = lambda: None
+
+    assert entity.oscillating is True
+    assert entity._last_oscillation_value is None
+
+    await entity.async_oscillate(False)
+    coordinator.async_set_control_value.assert_awaited_with("D0320F", 0)
+
+    coordinator.async_set_control_value.reset_mock()
+    await entity.async_oscillate(True)
+    coordinator.async_set_control_value.assert_awaited_with("D0320F", 45)
+
+
 async def test_fan_amf870_supports_oscillate() -> None:
     """Test the AMF870 fan exposes the oscillate feature."""
     entity, _ = _make_fan_entity("AMF870", {"D03102": 1, "D0310C": 2, "D0320F": 0})

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -464,27 +464,6 @@ async def test_fan_oscillate_noop_without_oscillation() -> None:
     coordinator.async_set_control_value.assert_not_called()
 
 
-async def test_fan_oscillate_keeps_fixed_on_value_for_legacy_maps() -> None:
-    """Test fixed-code models always write their documented on-value."""
-    # CX3120 uses OSCILLATION_MAP3 (on -> 45). The device reports 60 here: a
-    # value that must never be written back as if it switched oscillation on.
-    entity, coordinator = _make_fan_entity(
-        "CX3120",
-        {"D03102": 1, "D0310A": 3, "D0310C": 0, "D0320F": 60},
-    )
-    entity._handle_coordinator_update = lambda: None
-
-    assert entity.oscillating is True
-    assert entity._last_oscillation_value is None
-
-    await entity.async_oscillate(False)
-    coordinator.async_set_control_value.assert_awaited_with("D0320F", 0)
-
-    coordinator.async_set_control_value.reset_mock()
-    await entity.async_oscillate(True)
-    coordinator.async_set_control_value.assert_awaited_with("D0320F", 45)
-
-
 async def test_fan_amf870_supports_oscillate() -> None:
     """Test the AMF870 fan exposes the oscillate feature."""
     entity, _ = _make_fan_entity("AMF870", {"D03102": 1, "D0310C": 2, "D0320F": 0})

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -79,6 +79,7 @@ def test_default_fields() -> None:
     assert config.unavailable_filters == []
     assert config.unavailable_sensors == []
     assert config.oscillation is None
+    assert config.oscillation_is_angle is False
     assert config.create_fan is True
     assert config.requires_mode_cycling is False
 
@@ -101,6 +102,7 @@ def test_amf765_rotation_controls() -> None:
     config = DEVICE_MODELS[FanModel.AMF765]
     assert PhilipsApi.NEW2_OSCILLATION in config.numbers
     assert config.oscillation == {PhilipsApi.NEW2_OSCILLATION: PhilipsApi.OSCILLATION_MAP5}
+    assert config.oscillation_is_angle is True
 
 
 def test_amf870_rotation_controls() -> None:
@@ -109,3 +111,4 @@ def test_amf870_rotation_controls() -> None:
     assert PhilipsApi.NEW2_OSCILLATION in config.numbers
     assert PhilipsApi.NEW2_TARGET_TEMP in config.numbers
     assert config.oscillation == {PhilipsApi.NEW2_OSCILLATION: PhilipsApi.OSCILLATION_MAP5}
+    assert config.oscillation_is_angle is True

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -79,7 +79,6 @@ def test_default_fields() -> None:
     assert config.unavailable_filters == []
     assert config.unavailable_sensors == []
     assert config.oscillation is None
-    assert config.oscillation_is_angle is False
     assert config.create_fan is True
     assert config.requires_mode_cycling is False
 
@@ -102,7 +101,6 @@ def test_amf765_rotation_controls() -> None:
     config = DEVICE_MODELS[FanModel.AMF765]
     assert PhilipsApi.NEW2_OSCILLATION in config.numbers
     assert config.oscillation == {PhilipsApi.NEW2_OSCILLATION: PhilipsApi.OSCILLATION_MAP5}
-    assert config.oscillation_is_angle is True
 
 
 def test_amf870_rotation_controls() -> None:
@@ -111,4 +109,3 @@ def test_amf870_rotation_controls() -> None:
     assert PhilipsApi.NEW2_OSCILLATION in config.numbers
     assert PhilipsApi.NEW2_TARGET_TEMP in config.numbers
     assert config.oscillation == {PhilipsApi.NEW2_OSCILLATION: PhilipsApi.OSCILLATION_MAP5}
-    assert config.oscillation_is_angle is True

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from custom_components.philips_airpurifier.const import FanModel
+from custom_components.philips_airpurifier.const import FanModel, PhilipsApi
 from custom_components.philips_airpurifier.device_models import DEVICE_MODELS
 from custom_components.philips_airpurifier.model import (
     ApiGeneration,
@@ -94,3 +94,18 @@ def test_cx7550_registered() -> None:
     assert config.api_generation is ApiGeneration.GEN3
     assert config.create_fan is True
     assert config.heaters == []
+
+
+def test_amf765_rotation_controls() -> None:
+    """Test AMF765 exposes both the rotation toggle and the rotation angle."""
+    config = DEVICE_MODELS[FanModel.AMF765]
+    assert PhilipsApi.NEW2_OSCILLATION in config.numbers
+    assert config.oscillation == {PhilipsApi.NEW2_OSCILLATION: PhilipsApi.OSCILLATION_MAP5}
+
+
+def test_amf870_rotation_controls() -> None:
+    """Test AMF870 keeps the AMFxxx rotation angle alongside its target temperature."""
+    config = DEVICE_MODELS[FanModel.AMF870]
+    assert PhilipsApi.NEW2_OSCILLATION in config.numbers
+    assert PhilipsApi.NEW2_TARGET_TEMP in config.numbers
+    assert config.oscillation == {PhilipsApi.NEW2_OSCILLATION: PhilipsApi.OSCILLATION_MAP5}

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -282,6 +282,51 @@ async def test_number_set_value_positive_below_min_threshold(
     mock_number_coap_client.set_control_values.assert_called_with(data={PhilipsApi.NEW2_OSCILLATION: 30})
 
 
+async def test_amf870_creates_oscillation_and_target_temp_numbers(
+    hass: HomeAssistant,
+) -> None:
+    """Test the AMF870 exposes the rotation angle next to the target temperature."""
+    status = MOCK_STATUS_NUMBER | {"D01S05": "AMF870"}
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=f"AMF870 {TEST_NAME}",
+        data={
+            CONF_HOST: TEST_HOST,
+            CONF_MODEL: "AMF870",
+            CONF_NAME: TEST_NAME,
+            CONF_DEVICE_ID: TEST_DEVICE_ID,
+            CONF_STATUS: status,
+        },
+        unique_id=TEST_DEVICE_ID,
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch("custom_components.philips_airpurifier.CoAPClient") as mock_client_cls,
+        patch(
+            "custom_components.philips_airpurifier.coordinator.PhilipsAirPurifierCoordinator._start_observing",
+        ),
+    ):
+        client = AsyncMock()
+        client.get_status = AsyncMock(return_value=(status.copy(), 60))
+        mock_client_cls.create = AsyncMock(return_value=client)
+        mock_client_cls.return_value = client
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+
+    entity_registry = er.async_get(hass)
+    suffixes = {
+        e.unique_id.rpartition("-")[2]
+        for e in er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+        if e.domain == NUMBER_DOMAIN
+    }
+    assert PhilipsApi.NEW2_OSCILLATION.lower() in suffixes
+    assert PhilipsApi.NEW2_TARGET_TEMP.lower() in suffixes
+
+
 async def test_number_set_native_value_none_coerces_to_min(
     hass: HomeAssistant,
     init_number_integration: MockConfigEntry,


### PR DESCRIPTION
The AMF870 device config listed only the target temperature under `numbers`, which replaced rather than extended the AMF family defaults and silently dropped the rotation angle entity, leaving the model with no way to control its oscillation from Home Assistant.

Restore `NEW2_OSCILLATION` (0 = off, 30-350 degrees in 5 degree steps) alongside the target temperature, and declare an `oscillation` map for both AMF765 and AMF870 so the fan entity supports `fan.oscillate` and the oscillation toggle in the UI. The AMF765 kept the angle entity but never exposed the on/off control.

On the AMF family the rotation angle and the on/off state share one device key (D0320F), so switching oscillation back on now restores the angle the device last reported instead of overwriting it with a fixed value. Models with a constant on-value are unaffected: they report exactly that value while oscillating.

Also fix the misspelled `oscillaton` and `target_temp` translation keys in de/nl/bg, which never matched `strings.json`, so those number entities fell back to their English names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rotation-angle oscillation controls for AMF765 and AMF870 devices.
  * Re-enabling oscillation restores the last reported angle, or defaults to 90° when unavailable.
  * AMF870 now provides both oscillation and target-temperature controls.

* **Bug Fixes**
  * Restored AMF870 rotation control.
  * Corrected oscillation and target-temperature entity handling.
  * Fixed German, Dutch and Bulgarian translations, including German target-temperature wording.

* **Documentation**
  * Documented rotation behaviour and updated supported-device information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->